### PR TITLE
Adds a pallet project file

### DIFF
--- a/pallet.clj
+++ b/pallet.clj
@@ -57,7 +57,8 @@
               :selectors #{:default}}}
 
   :groups [(group-spec "clojars"
-                       :extends [(java {}) (leiningen {}) (git {})]
+                       :extends [with-automated-admin-user
+                                 (java {}) (leiningen {}) (git {})]
                        :phases {:configure (plan-fn
                                              (setup-machine)
                                              (clone-repo)

--- a/pallet.clj
+++ b/pallet.clj
@@ -1,0 +1,68 @@
+;;; Pallet project configuration file for clojars
+(require
+ '[pallet.crate.git :refer [git clone]]
+ '[pallet.crate.java :refer [java]]
+ '[pallet.crate.lein :refer [lein leiningen]])
+
+
+(def repo "git://github.com/ato/clojars-web.git")
+
+(defplan setup-machine
+  []
+  (packages
+   :apt ["sqlite3"]
+   :aptitude ["sqlite3"]
+   :brew ["sqlite"]))
+
+(defplan clone-repo
+  []
+  (with-action-options {:script-prefix :no-sudo}
+    (remote-directory ".ssh" :mode "0755")
+    (remote-file
+     ".ssh/config"
+     :content "Host github.com\n\tStrictHostKeyChecking no\n"
+     :no-versioning true) ; pallet beta.1 workaround
+    (clone repo)))
+
+(defplan migrate-db
+  []
+  (with-action-options {:script-prefix :no-sudo :script-dir "clojars-web"}
+    (lein "migrate")))
+
+(defplan import-test-data
+  []
+  (with-action-options {:script-prefix :no-sudo :script-dir "clojars-web"}
+    (exec-checked-script
+     "Import Test Data"
+     ("wget" "http://meshy.org/~ato/clojars-test-data.sql.gz")
+     ("mkdir" -p data)
+     ("rm" -f "data/dev_db")
+     (pipe ("gunzip" -c "clojars-test-data.sql.gz")
+           ("sqlite3" "data/dev_db")))))
+
+(defplan run
+  []
+  (with-action-options {:script-prefix :no-sudo :script-dir "clojars-web"}
+    (exec-checked-script
+     "Run clojars"
+     ("(" nohup ("lein" run) "&" ")")
+     ("sleep" 5)))) ; let nohup detach
+
+(defproject clojars
+  :provider {:vmfest
+             {:node-spec
+              {:image {:os-family :ubuntu :os-version-matches "12.04"
+                       :os-64-bit true}}
+              :group-suffix "u1204"
+              :selectors #{:default}}}
+
+  :groups [(group-spec "clojars"
+                       :extends [(java {}) (leiningen {}) (git {})]
+                       :phases {:configure (plan-fn
+                                             (setup-machine)
+                                             (clone-repo)
+                                             (migrate-db)
+                                             (import-test-data)
+                                             (run))
+                                :import-test-data (plan-fn
+                                                    (import-test-data))})])

--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
              :pallet {:dependencies
                       [[org.cloudhoist/pallet-vmfest "0.3.0-alpha.1"]
                        [org.clojars.tbatchelli/vboxjxpcom "4.2.4"]
-                       [com.palletops/pallet "0.8.0-beta.1"]
+                       [com.palletops/pallet "0.8.0-beta.4"]
                        [com.palletops/java-crate "0.8.0-beta.1"]
                        [com.palletops/lein-crate "0.8.0-alpha.1"]
                        [com.palletops/git-crate "0.8.0-alpha.1"]
@@ -47,7 +47,7 @@
   :plugins [[lein-ring "0.7.3" :exclusions [thneed]]
             ;fix downloading -snapshot all the time
             [thneed "1.0.0"]
-            [com.palletops/pallet-lein "0.6.0-beta.4"]]
+            [com.palletops/pallet-lein "0.6.0-beta.8"]]
   :aliases {"migrate" ["run" "-m" "clojars.db.migrate"]}
   :ring {:handler clojars.web/clojars-app}
   :aot [clojars.scp]

--- a/project.clj
+++ b/project.clj
@@ -34,10 +34,20 @@
                                    [nailgun-shim "0.0.1"]]}
              :dev {:dependencies [[kerodon "0.0.7"]
                                   [nailgun-shim "0.0.1"]]
-                   :resource-paths ["local-resources"]}}
+                   :resource-paths ["local-resources"]}
+             :pallet {:dependencies
+                      [[org.cloudhoist/pallet-vmfest "0.3.0-alpha.1"]
+                       [org.clojars.tbatchelli/vboxjxpcom "4.2.4"]
+                       [com.palletops/pallet "0.8.0-beta.1"]
+                       [com.palletops/java-crate "0.8.0-beta.1"]
+                       [com.palletops/lein-crate "0.8.0-alpha.1"]
+                       [com.palletops/git-crate "0.8.0-alpha.1"]
+                       [ch.qos.logback/logback-classic "1.0.9"]
+                       [org.slf4j/jcl-over-slf4j "1.7.2"]]}}
   :plugins [[lein-ring "0.7.3" :exclusions [thneed]]
             ;fix downloading -snapshot all the time
-            [thneed "1.0.0"]]
+            [thneed "1.0.0"]
+            [com.palletops/pallet-lein "0.6.0-beta.4"]]
   :aliases {"migrate" ["run" "-m" "clojars.db.migrate"]}
   :ring {:handler clojars.web/clojars-app}
   :aot [clojars.scp]


### PR DESCRIPTION
This is a basic pallet configuration.  It creates a vm running clojars from a
local checkout using the test data.

To use it:
 lein pallet add-vmfest-image \
   https://s3.amazonaws.com/vmfest-images/ubuntu-10-10-64bit-server.vdi.gz
 lein pallet up

If you think this might be useful, we could improve it as needed.