### PR TITLE
Thread mailer through system

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -63,6 +63,8 @@
                                   [kerodon "0.7.0"
                                    :exclusions [org.apache.httpcomponents/httpcore]]
                                   [clj-http-lite "0.3.0"]
-                                  [com.google.jimfs/jimfs 1.0]]
+                                  [com.google.jimfs/jimfs 1.0]
+                                  [net.polyc0l0r/bote "0.1.0"
+                                   :exclusions [org.clojars.kjw/slf4j-simple]]]
                    :resource-paths ["local-resources"]}
    :project/test  {}})

--- a/src/clojars/email.clj
+++ b/src/clojars/email.clj
@@ -1,21 +1,17 @@
 (ns clojars.email
-  (:require [clojars.config :as config])
   (:import [org.apache.commons.mail SimpleEmail]))
 
-(defn send-out [email]
-  (.send email))
-
-(defn send-email [to subject message]
-  (let [{:keys [hostname username password port ssl from]} (config/config :mail)
-        mail (doto (SimpleEmail.)
-               (.setHostName (or hostname "localhost"))
-               (.setSslSmtpPort (str (or port 25)))
-               (.setSmtpPort (or port 25))
-               (.setSSL (or ssl false))
-               (.setFrom (or from "noreply@clojars.org") "Clojars")
-               (.addTo to)
-               (.setSubject subject)
-               (.setMsg message))]
-    (when (and username password)
-      (.setAuthentication mail username password))
-    (send-out mail)))
+(defn simple-mailer [{:keys [hostname username password port ssl from] :as config}]
+  (fn [to subject message]
+    (let [mail (doto (SimpleEmail.)
+                 (.setHostName (or hostname "localhost"))
+                 (.setSslSmtpPort (str (or port 25)))
+                 (.setSmtpPort (or port 25))
+                 (.setSSL (or ssl false))
+                 (.setFrom (or from "noreply@clojars.org") "Clojars")
+                 (.addTo to)
+                 (.setSubject subject)
+                 (.setMsg message))]
+      (when (and username password)
+        (.setAuthentication mail username password))
+      (.send mail))))

--- a/src/clojars/routes/user.clj
+++ b/src/clojars/routes/user.clj
@@ -9,7 +9,7 @@
     (auth/try-account
      (view/show-user db account user))))
 
-(defn routes [db]
+(defn routes [db mailer]
   (compojure/routes
    (GET "/profile" {:keys [flash]}
         (auth/with-account
@@ -24,7 +24,7 @@
    (GET "/forgot-password" _
         (view/forgot-password-form))
    (POST "/forgot-password" {:keys [params]}
-         (view/forgot-password db params))
+         (view/forgot-password db mailer params))
 
    (GET "/password-resets/:reset-code" [reset-code]
         (view/edit-password-form db reset-code))

--- a/src/clojars/system.clj
+++ b/src/clojars/system.clj
@@ -1,5 +1,6 @@
 (ns clojars.system
   (:require [clojars
+             [email :refer [simple-mailer]]
              [ring-servlet-patch :as patch]
              [search :refer [lucene-component]]
              [stats :refer [file-stats]]
@@ -42,10 +43,11 @@
          :stats (file-stats (:stats-dir config))
          :index-factory #(clucy/disk-index (:index-path config))
          :search (lucene-component)
+         :mailer (simple-mailer (:mail config))
          :clojars-app   (endpoint-component web/handler-optioned))
         (component/system-using
          {:http [:app]
           :app  [:clojars-app]
           :stats [:fs-factory]
           :search [:index-factory :stats]
-          :clojars-app [:db :error-reporter :stats :search]}))))
+          :clojars-app [:db :error-reporter :stats :search :mailer]}))))

--- a/src/clojars/web.clj
+++ b/src/clojars/web.clj
@@ -37,7 +37,7 @@
              [resource :refer [wrap-resource]]
              [session :refer [wrap-session]]]))
 
-(defn main-routes [db reporter stats search-obj]
+(defn main-routes [db reporter stats search-obj mailer]
   (routes
    (GET "/" _
         (try-account
@@ -62,7 +62,7 @@
    (artifact/routes db reporter stats)
    ;; user routes must go after artifact routes
    ;; since they both catch /:identifier
-   (user/routes db)
+   (user/routes db mailer)
    (api/routes db stats)
    (GET "/error" _ (throw (Exception. "What!? You really want an error?")))
    (PUT "*" _ {:status 405 :headers {} :body "Did you mean to use /repo?"})
@@ -107,7 +107,7 @@
         (secure-session req)
         (regular-session req)))))
 
-(defn clojars-app [db reporter stats search]
+(defn clojars-app [db reporter stats search mailer]
   (routes
    (context "/repo" _
             (-> (repo/routes db search)
@@ -120,7 +120,7 @@
                 (repo/wrap-exceptions reporter)
                 (repo/wrap-file (:repo config))
                 (repo/wrap-reject-double-dot)))
-   (-> (main-routes db reporter stats search)
+   (-> (main-routes db reporter stats search mailer)
        (friend/authenticate
         {:credential-fn (credential-fn db)
          :workflows [(workflows/interactive-form)
@@ -137,5 +137,5 @@
        (wrap-not-modified)
        (wrap-exceptions reporter))))
 
-(defn handler-optioned [{:keys [db error-reporter stats search]}]
-  (clojars-app (:spec db) error-reporter stats search))
+(defn handler-optioned [{:keys [db error-reporter stats search mailer]}]
+  (clojars-app (:spec db) error-reporter stats search mailer))

--- a/src/clojars/web/user.clj
+++ b/src/clojars/web/user.clj
@@ -13,7 +13,6 @@
                                  submit-button
                                  email-field]]
             [clojars.web.safe-hiccup :refer [form-to]]
-            [clojars.email :as email]
             [ring.util.response :refer [response redirect]]
             [valip.core :refer [validate]]
             [valip.predicates :as pred]))
@@ -127,12 +126,12 @@
                           :email-or-username)
               (submit-button "Email me a password reset link"))]))
 
-(defn forgot-password [db {:keys [email-or-username]}]
+(defn forgot-password [db mailer {:keys [email-or-username]}]
   (when-let [user (find-user-by-user-or-email db email-or-username)]
     (let [reset-code (db/set-password-reset-code! db email-or-username)
           base-url (:base-url config)
           reset-password-url (str base-url "/password-resets/" reset-code)]
-      (email/send-email (user :email)
+      (mailer (user :email)
         "Password reset for Clojars"
         (->> ["Hello,"
               "We received a request from someone, hopefully you, to reset the password of your clojars user."

--- a/test/clojars/test/test_helper.clj
+++ b/test/clojars/test/test_helper.clj
@@ -2,9 +2,10 @@
   (:require [clojars
              [config :refer [config]]
              [db :as db]
+             [email :as email]
              [errors :as errors]
-             [search :as search]
              [stats :as stats]
+             [search :as search]
              [system :as system]
              [web :as web]]
             [clojars.db.migrate :as migrate]
@@ -26,13 +27,7 @@
                        :subprotocol "sqlite"
                        :subname ":memory:"}
                   :repo "data/test/repo"
-                  :bcrypt-work-factor 12
-                  :mail {:hostname "smtp.gmail.com"
-                         :from "noreply@clojars.org"
-                         :username "clojars@pupeno.com"
-                         :password "fuuuuuu"
-                         :port 465 ; If you change ssl to false, the port might not be effective, search for .setSSL and .setSslSmtpPort
-                         :ssl true}})
+                  :bcrypt-work-factor 12})
 
 (defn using-test-config [f]
   (with-redefs [config test-config]
@@ -76,8 +71,16 @@
 
 (declare ^:dynamic test-port)
 
-(defn app []
-  (web/clojars-app *db* (quiet-reporter) (no-stats) (no-search)))
+
+(defn app
+  ([] (app {}))
+  ([{:keys [:db :error-reporter :stats :search :mailer]
+     :or {:db *db*
+          :error-reporter (quiet-reporter)
+          :stats (no-stats)
+          :search (no-search)
+          :mailer nil}}]
+   (web/clojars-app db error-reporter stats search mailer)))
 
 (declare ^:dynamic system)
 

--- a/test/clojars/test/unit/email.clj
+++ b/test/clojars/test/unit/email.clj
@@ -1,0 +1,75 @@
+(ns clojars.test.unit.email
+  (:require [bote.core :refer [create-smtp-server]]
+            [clojars.email :refer :all]
+            [clojure.test :refer :all])
+  (:import javax.net.ssl.SSLException
+           org.apache.commons.mail.EmailException
+           [org.subethamail.smtp.auth EasyAuthenticationHandlerFactory LoginFailedException UsernamePasswordValidator]))
+
+(deftest simple-mailer-sends-emails
+  (let [transport (promise)
+        server (create-smtp-server #(deliver transport %) :port 0)]
+    (try
+      (.start server)
+      ((simple-mailer {:host "localhost"
+                       :port (.getPort server)
+                       :from "example@example.org"})
+       "to@example.org"
+       "the subject"
+       "A message")
+      (let [email (deref transport 100 nil)]
+        (is email)
+        (is (= "A message" (.trim (:content email))))
+        (is (= "the subject" (:subject email)))
+        (is (= "to@example.org" (:to email)))
+        (is (= "example@example.org" (:from email))))
+      (finally (.stop server)))))
+
+(deftest simple-mailer-sends-username-and-password
+  (let [transport (promise)
+        server (create-smtp-server #(deliver transport %) :port 0)]
+    (try
+      (.setAuthenticationHandlerFactory
+       server
+       (EasyAuthenticationHandlerFactory.
+        (reify UsernamePasswordValidator
+          (login [t username password]
+            (when (or (not= username "username")
+                      (not= password "password"))
+              (throw (LoginFailedException.)))))))
+      (.start server)
+      ((simple-mailer {:host "localhost"
+                       :port (.getPort server)
+                       :from "example@example.org"
+                       :username "username"
+                       :password "password"})
+       "to@example.org"
+       "the subject"
+       "A message")
+      (is (deref transport 100 nil))
+      (finally (.stop server)))))
+
+
+(deftest simple-mailer-uses-tls
+  (let [transport (promise)
+        server (create-smtp-server #(deliver transport %)
+                                   :port 0)]
+    (try
+      (.start server)
+      ;;TODO actually setting up an ssl server
+      ;;and checking the message would be better
+      ;;but it looks like the tls stuff is a mess
+      ;;this sufficies to say it tried
+      ((simple-mailer {:host "localhost"
+                       :port (.getPort server)
+                       :from "example@example.org"
+                       :ssl true})
+            "to@example.org"
+            "the subject"
+       "A message")
+      (is false)
+      (catch EmailException e
+        ;;traverse to the root cause
+        (let [e (.getCause (.getCause e))]
+          (is (instance? SSLException e))))
+      (finally (.stop server)))))


### PR DESCRIPTION
Pass a function through as a mailer. Use this for sending password
resets.

The prod/dev systems can use the normal one. Tests are added for it
which spawn an smtp server and connect to it.  Tests for other parts of
the system can pass a mailer that just sends the data to a promise for
verification.