### PR TITLE
Render html response for invalid form

### DIFF
--- a/src/clojars/friend/registration.clj
+++ b/src/clojars/friend/registration.clj
@@ -1,6 +1,6 @@
 (ns clojars.friend.registration
   (:require [cemerick.friend.workflows :as workflow]
-            [ring.util.response :refer [response]]
+            [ring.util.response :refer [response content-type]]
             [clojars.web.user :refer [register-form new-user-validations]]
             [clojars.db :refer [add-user]]
             [valip.core :refer [validate]]))
@@ -11,7 +11,9 @@
                                    :password password
                                    :pgp-key pgp-key}
                          (new-user-validations db confirm))]
-    (response (register-form (apply concat (vals errors)) email username))
+    (->
+     (response (register-form (apply concat (vals errors)) email username))
+     (content-type "text/html"))
     (do (add-user db email username password pgp-key)
         (workflow/make-auth {:identity username :username username}))))
 


### PR DESCRIPTION
There is a test that tests the behavior of an invalid form. I tried to make it fail by checking for the content-type. I spent some time on it and couldn't get kerodon to place nice with finding the headers.

I think there are two follow ups to this PR:
1) Render valid inputs when there is an error. I.E leave username in the input if it is valid but password isn't. Right now only email behaves this way.
2) Add a headers assertion to kerodon