### PR TITLE
Add support for PostgreSQL

### DIFF
--- a/clojars-postgresql.sql
+++ b/clojars-postgresql.sql
@@ -1,0 +1,34 @@
+create table users
+       (id serial not null PRIMARY KEY,
+        "user" TEXT UNIQUE NOT NULL,
+        password TEXT NOT NULL,
+        salt TEXT NOT NULL,
+        email TEXT NOT NULL,
+        ssh_key TEXT NOT NULL,
+        created DATE NOT NULL);
+
+create table jars
+       (id serial not null PRIMARY KEY,
+        group_name TEXT NOT NULL,
+        jar_name TEXT NOT NULL,
+        version TEXT NOT NULL,
+        "user" TEXT NOT NULL,
+        created DATE NOT NULL,
+        description TEXT,
+        homepage TEXT,
+        scm TEXT,
+        authors TEXT);
+
+create table deps
+       (id serial not null PRIMARY KEY,
+        group_name TEXT NOT NULL,
+        jar_name TEXT NOT NULL,
+        version TEXT NOT NULL,
+        dep_group_name TEXT NOT NULL,
+        dep_jar_name TEXT NOT NULL,
+        dep_version TEXT NOT NULL);
+
+create table groups
+       (id serial not null PRIMARY KEY,
+        name TEXT NOT NULL,
+        "user" TEXT NOT NULL);

--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,7 @@
                  [hiccup "1.0.3"]
                  [cheshire "5.4.0"]
                  [org.xerial/sqlite-jdbc "3.8.11.2"]
+                 [org.postgresql/postgresql "9.4-1201-jdbc4"]
                  [org.apache.commons/commons-email "1.2"]
                  [commons-codec "1.6"]
                  [net.cgrand/regex "1.0.1"

--- a/src/clojars/config.clj
+++ b/src/clojars/config.clj
@@ -22,10 +22,6 @@
 (defn parse-resource [f]
   (when-let [r (io/resource f)] (read-string (slurp r))))
 
-;; we attempt to read a config.clj from the classpath at load time
-;; this is handy for interactive development and unit tests
-(def config (merge default-config (parse-resource "config.clj")))
-
 (defn url-decode [s]
   (java.net.URLDecoder/decode s "UTF-8"))
 
@@ -78,6 +74,10 @@
        (assoc m k ((or f identity) x))
        m))
    {} env-vars))
+
+;; we attempt to read a config.clj from the classpath at load time
+;; this is handy for interactive development and unit tests
+(def config (merge default-config (parse-resource "config.clj") (parse-env)))
 
 (defn parse-args [args defaults]
   (cli args


### PR DESCRIPTION
A few concerns:
- Search triggers and table are not included in postgresql schema. I couldn't get search working, but I think that's because Lucene. 
- Environment variables now override default and config.clj for uberjar (couldn't figure out how to set PG URL without hard coding otherwise, but this is generally good i think).
- Depending on how the JDBC URL is set, the file `clojars-postgres.sql` or `clojars-postgresql.sql` might be used. I'll fix this in a future PR.
