### PR TITLE
Ensure search input is auto-focused (Fix #437)

### DIFF
--- a/src/clojars/web/common.clj
+++ b/src/clojars/web/common.clj
@@ -169,6 +169,7 @@
                 :name "q"
                 :id "search"
                 :placeholder "Search projects..."
+                :autofocus true
                 :required true}]
        [:input {:id "search-button"
                 :value "Search"


### PR DESCRIPTION
This adds the `autofocus` attribute to the search input displayed on the initial page. The feature is supported by [major browsers](http://caniuse.com/#feat=autofocus).