### PR TITLE
Preserve input values on validation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ home
 *.iml
 
 /.lein-deps-sum
+/.lein-repl-history
 /.lein-failures
 /.nrepl-port
 /local-resources

--- a/src/clojars/friend/registration.clj
+++ b/src/clojars/friend/registration.clj
@@ -12,7 +12,10 @@
                                    :pgp-key pgp-key}
                          (new-user-validations db confirm))]
     (->
-     (response (register-form (apply concat (vals errors)) email username))
+     (response (register-form {:errors (apply concat (vals errors))
+                               :email email
+                               :username username
+                               :pgp-key pgp-key}))
      (content-type "text/html"))
     (do (add-user db email username password pgp-key)
         (workflow/make-auth {:identity username :username username}))))

--- a/src/clojars/routes/user.clj
+++ b/src/clojars/routes/user.clj
@@ -18,8 +18,8 @@
          (auth/with-account
            (view/update-profile db account params)))
 
-   (GET "/register" _
-        (view/register-form))
+   (GET "/register" {:keys [params]}
+        (view/register-form params))
 
    (GET "/forgot-password" _
         (view/forgot-password-form))

--- a/src/clojars/web/user.clj
+++ b/src/clojars/web/user.clj
@@ -17,7 +17,7 @@
             [valip.core :refer [validate]]
             [valip.predicates :as pred]))
 
-(defn register-form [ & [errors email username pgp-key]]
+(defn register-form [{:keys [errors email username pgp-key]}]
   (html-doc nil "Register"
             [:div.small-section
              [:h1 "Register"]
@@ -29,7 +29,8 @@
                                     :placeholder "bob@example.com"}
                                    :email)
                       (label :username "Username")
-                      (text-field {:required true
+                      (text-field {:value username
+                                   :required true
                                    :placeholder "bob"}
                                   :username)
                       (label :password "Password")

--- a/test/clojars/test/integration/users.clj
+++ b/test/clojars/test/integration/users.clj
@@ -41,6 +41,8 @@
       (fill-in "Username" "dantheman")
       (press "Register")
       (has (status? 200))
+      (has (value? [:input#username] "dantheman"))
+      (has (value? [:input#email] "test@example.com"))
       (within [:div.error :ul :li]
               (has (text? "Password and confirm password must match")))
 


### PR DESCRIPTION
Figured I would ease into it gently with an easy one. I didn't fill the passwords (e.g. passwords match but public key is invalid) as that seems to be the norm on other websites.

![](http://g.recordit.co/MA46CxD8Xy.gif)