### PR TITLE
Listen only on localhost

### DIFF
--- a/src/clojars/config.clj
+++ b/src/clojars/config.clj
@@ -5,7 +5,7 @@
 
 (def default-config
   {:port 8080
-   :bind "0.0.0.0"
+   :bind "127.0.0.1"
    :db {:classname "org.sqlite.JDBC"
         :subprotocol "sqlite"
         :subname "data/db"}


### PR DESCRIPTION
Disabling from the previous state where the app would listen on all
interfaces, to listening only on the localhost.

The change was prompted by this issue:
https://github.com/clojars/clojars-web/issues/457