### PR TITLE
Updated the README with production deploy step

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,10 @@ Deployment
 Also see [Configuration](#configuration).
 
 1. Compile with: `lein uberjar`
-2. Deploy `target/uberjar/clojars-web-*-standalone.jar` to the server
-3. Run the migrations `java -cp clojars-web-*-standalone.jar clojure.main -m clojars.tools.migrate-db`
-4. Run the production system: `java -jar clojars-web-*-standalone.jar`
+1. Deploy `target/uberjar/clojars-web-*-standalone.jar` to the server
+1. Run the migrations `java -cp clojars-web-*-standalone.jar clojure.main -m clojars.tools.migrate-db`
+1. Set Yeller token `export YELLER_TOKEN="foo-bar"`
+1. Run the production system: `java -jar clojars-web-*-standalone.jar`
 
 Configuration
 -------------


### PR DESCRIPTION
If YELLER_TOKEN environment variable is not set, when trying to run the
app following the steps in the README an exception is raised:

```
  $ java -jar target/uberjar/clojars-web-26-SNAPSHOT-standalone.jar
  clojars-web: enabling yeller client
  Exception in thread "main" java.lang.AssertionError: Assert failed:
  Yeller client must be passed your api key as a string under :token, but
  got nil from (:token options)
  (string? (:token options))
	at yeller.clojure.client$client.invoke(client.clj:157)
	at clojars.main$_main.doInvoke(main.clj:25)
	at clojure.lang.RestFn.invoke(RestFn.java:397)
	at clojure.lang.AFn.applyToHelper(AFn.java:152)
	at clojure.lang.RestFn.applyTo(RestFn.java:132)
	at clojars.main.main(Unknown Source)
```
Setting the environment variable prevents the exception.

Switched from using sequentially listed numbers of steps, to using
Markdown's listing, by just using '1., 1., ...'