### PR TITLE
Don't use stop words when indexing for search.

### DIFF
--- a/src/clojars/search.clj
+++ b/src/clojars/search.clj
@@ -35,7 +35,8 @@
 
 ;; TODO: make this easy to do from clucy
 (defonce analyzer (let [a (PerFieldAnalyzerWrapper.
-                           (StandardAnalyzer. clucy/*version*))]
+                           ;; Our default analyzer has no stop words.
+                           (StandardAnalyzer. clucy/*version* #{}))]
                     (doseq [[field {:keys [analyzed]}] field-settings
                             :when (false? analyzed)]
                       (.addAnalyzer a (name field) (KeywordAnalyzer.)))

--- a/test/clojars/test/unit/search.clj
+++ b/test/clojars/test/unit/search.clj
@@ -53,10 +53,8 @@
              [lein-ring]))
       (is (= (map #(dissoc % :licenses) (search lc "ring" 1))
              [lein-ring]))
-      (comment
-        ;;TODO fix query parser to not ignore words #243
-        (is (= (map #(dissoc % :licenses) (search lc "at-at" 1))
-             [at-at])))
+      (is (= (map #(dissoc % :licenses) (search lc "at-at" 1))
+             [at-at]))
       (finally
         (component/stop lc)))))
 


### PR DESCRIPTION
This disables the default list of stop words used by Lucene's
StandardAnalyzer. Stop words don't work well when indexing text that
tends more toward non-prose.

In my tests, this increases the size of the Lucene index on disk by
about 1%, but gives better search results.  For example, now a search
for "at" will return an item that has the artifact-id "at-at" or an item
that references "at-at" in its description.

Fixes #243.