### PR TITLE
Stop reporting exceptions from redeploying non-snapshots

### DIFF
--- a/src/clojars/errors.clj
+++ b/src/clojars/errors.clj
@@ -38,7 +38,8 @@
    (report-error reporter e nil))
   ([reporter e extra]
    (let [id (error-id)]
-     (-report-error reporter e extra id)
+     (when-not (false? (:report? (ex-data e)))
+       (-report-error reporter e extra id))
      id)))
 
 (defn report-ring-error [reporter e request]

--- a/src/clojars/routes/repo.clj
+++ b/src/clojars/routes/repo.clj
@@ -84,7 +84,7 @@
          (.exists (io/file (config :repo) (string/replace group-id "." "/")
                     artifact-id version filename)))
    (throw (ex-info "redeploying non-snapshots is not allowed (see http://git.io/vO2Tg)"
-            {}))))
+            {:report? false}))))
 
 (defn validate-deploy [group-id artifact-id version filename]
   (try


### PR DESCRIPTION
Yeller doesn't need to get exceptions about redeploying non-snapshots as
this is a common user error/action, and doesn't indicate a fault in
Clojars.

Fixes #465