### PR TITLE
Select dependency co-ordinates and lein deploy steps when clicked

### DIFF
--- a/src/clojars/web/dashboard.clj
+++ b/src/clojars/web/dashboard.clj
@@ -2,7 +2,8 @@
   (:require [clojars.web.common :refer [html-doc html-doc-with-large-header jar-link group-link tag]]
             [clojars.db :refer [jars-by-username find-groupnames recent-jars]]
             [clojars.stats :as stats]
-            [hiccup.element :refer [unordered-list link-to]]))
+            [hiccup.element :refer [unordered-list link-to]]
+            [clojars.web.helpers :as helpers]))
 
 (defn recent-jar [stats jar-map]
   (let [description (:description jar-map)
@@ -22,14 +23,15 @@
 (defn index-page [db stats account]
   (html-doc-with-large-header nil {:account account}
     [:article.row
+     (helpers/select-text-script)
      [:div.push-information.col-md-6.col-lg-6.col-sm-6.col-xs-12
       [:h3.push-header "Push with Leiningen"]
-      [:div.push-example
+      [:div#leiningen.push-example {:onClick "selectText('leiningen');"}
        [:pre.push-example-leiningen
         (tag "$") " lein deploy clojars\n"]]]
      [:div.push-information.col-md-6.col-lg-6.col-sm-6.col-xs-12
       [:h3.push-header "Maven Repository"]
-      [:div.push-example
+      [:div#maven.push-example {:onClick "selectText('maven');"}
        [:pre
         (tag "<repository>\n")
         (tag "  <id>") "clojars.org" (tag "</id>\n")

--- a/src/clojars/web/helpers.clj
+++ b/src/clojars/web/helpers.clj
@@ -1,6 +1,7 @@
 (ns clojars.web.helpers
   (:require [clojure.java.io :as io]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [clojars.web.safe-hiccup :as hiccup]))
 
 (defn public-resource-exists?
   "Takes a path and checks whether the resource exists under the public directory
@@ -36,3 +37,19 @@
            :srcset (->> (filter identity [(srcset-part base extension "2x")
                                           (srcset-part base extension "3x")])
                         (str/join ", "))}]))
+
+(defn select-text-script []
+  (hiccup/raw "<script>
+                     function selectText( containerid ) {
+                       var node = document.getElementById( containerid );
+
+                       if ( window.getSelection ) {
+                         if ( window.getSelection().type != \"Range\" ) {
+                           var range = document.createRange();
+                           range.selectNodeContents( node );
+                           window.getSelection().removeAllRanges();
+                           window.getSelection().addRange( range );
+                         }
+                       }
+                     }
+               </script>"))

--- a/src/clojars/web/jar.clj
+++ b/src/clojars/web/jar.clj
@@ -6,7 +6,7 @@
             hiccup.core
             [hiccup.element :refer [link-to image]]
             [hiccup.form :refer [submit-button]]
-            [clojars.web.safe-hiccup :refer [form-to]]
+            [clojars.web.safe-hiccup :refer [form-to raw]]
             [clojars.maven :refer [jar-to-pom-map commit-url github-info]]
             [clojars.auth :refer [authorized?]]
             [clojars.db :refer [find-jar jar-exists]]
@@ -85,6 +85,7 @@
   (html-doc (str (:jar_name jar) " " (:version jar)) {:account account}
             (let [pom-map (jar-to-pom-map reporter jar)]
               [:div.light-article.row
+               (helpers/select-text-script)
                [:div#jar-title.col-sm-9.col-lg-9.col-xs-12.col-md-9
                 [:h1 (jar-link jar)]
                 [:p.description (:description jar)]
@@ -113,7 +114,8 @@
                   [:p.error "Oops. We hit an error opening the metadata POM file for this project "
                    "so some details are not available."])
                 [:h2 "Leiningen"]
-                [:div.package-config-example
+                [:div#leiningen-coordinates.package-config-example
+                 {:onClick "selectText('leiningen-coordinates');"}
                  [:pre
                   (tag "[")
                   (jar-name jar)
@@ -121,7 +123,8 @@
                    (:version jar) "\""] (tag "]") ]]
 
                 [:h2 "Gradle"]
-                [:div.package-config-example
+                [:div#gradle-coordinates.package-config-example
+                 {:onClick "selectText('gradle-coordinates');"}
                  [:pre
                   "compile "
                   [:span.string
@@ -134,7 +137,8 @@
                    \"]]]
 
                 [:h2 "Maven"]
-                [:div.package-config-example
+                [:div#maven-coordinates.package-config-example
+                 {:onClick "selectText('maven-coordinates');"}
                  [:pre
                   (tag "<dependency>\n")
                   (tag "  <groupId>") (:group_name jar) (tag "</groupId>\n")
@@ -178,7 +182,9 @@
                   "Want to display the "
                   (link-to {:target "_blank"} (version-badge-url jar) "latest version")
                   " of your project on Github? Use the markdown code below!"]
-                 [:textarea {:readonly "readonly" :rows 4} (badge-markdown jar)]
+                 [:textarea#version-badge
+                  {:readonly "readonly" :rows 4 :onClick "selectText('version-badge')"}
+                  (badge-markdown jar)]
                  ]
                 ]])))
 


### PR DESCRIPTION
This allows you to click once on a co-ordinate or the surrounding div
and to select all of the text inside it. The inline JS is slightly
questionable but probably just inside the margin of taste, as we don't
really have any other JS on the site.

There is one semi-bug in this, which is when you have a selection and you click outside the selection but within the text field. It should just remove the selection, but it selects the whole box. I had a few tries at workarounds, but I wasn't able to find one.

Fixes #276

Ignore the colours in the gif's below, that's an artifact of the gif.

![selection1](https://cloud.githubusercontent.com/assets/811954/12348232/2492c200-bbca-11e5-8056-ccbf9a94f54b.gif)

![dashboard](https://cloud.githubusercontent.com/assets/811954/12348233/2497b09e-bbca-11e5-8053-b34d3e377398.gif)