### PR TITLE
Fix arity exception when adding test users for dev

### DIFF
--- a/src/clojars/dev/setup.clj
+++ b/src/clojars/dev/setup.clj
@@ -24,7 +24,7 @@
              (println "User" name "already exists")
              (do
                (printf "Adding user %s/%s\n" name name)
-               (db/add-user db (str name "@example.com") name name "")))
+               (db/add-user db (str name "@example.com") name name)))
            name)
     (range n)))
 


### PR DESCRIPTION
This fixes an exception that is risen when trying to setup dev environment with clojars.tools.setup-dev
