### PR TITLE
Improve login error messages

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject clojars-web "31-SNAPSHOT"
   :min-lein-version "2.0.0"
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.cli "0.2.1"]
                  [yeller-clojure-client "1.4.1"]
                  [org.apache.maven/maven-model "3.0.4"

--- a/resources/public/stylesheets/screen.css
+++ b/resources/public/stylesheets/screen.css
@@ -87,6 +87,11 @@ hr {
   display: block;
 }
 
+.error {
+  color: #c9302c;
+  margin-bottom: 10px;
+}
+
 .page-nav {
   clear: left;
   font-size: 1.2em;

--- a/src/clojars/web/login.clj
+++ b/src/clojars/web/login.clj
@@ -4,7 +4,8 @@
             [hiccup.form :refer [label text-field
                                  password-field submit-button]]
             [ring.util.response :refer [redirect]]
-            [clojars.web.safe-hiccup :refer [form-to]]))
+            [clojars.web.safe-hiccup :refer [form-to]]
+            [clojure.string :as str]))
 
 (defn login-form [login_failed username]
   (html-doc "Login" {}
@@ -14,12 +15,16 @@
      (link-to "/register" "Sign up!")]
 
     (when login_failed
-      [:div [:p.error "Incorrect username and/or password."]
+      [:div
+       [:p.error "Incorrect username and/or password."]
+       (when (some? (str/index-of username \@))
+         [:p.error "Make sure that you are using your username, and not your email to log in."])
        [:p.hint "If you have not logged in since April 2012 when "
         [:a {:href "https://groups.google.com/group/clojure/browse_thread/thread/5e0d48d2b82df39b"}
          "the insecure password hashes were wiped"]
         ", please use the " [:a {:href "/forgot-password"} "forgot password"]
-        " functionality to reset your password."]])
+        " functionality to reset your password."]
+       ])
     (form-to [:post "/login" :class "row"]
              (label :username "Username")
              (text-field {:placeholder "bob"

--- a/src/clojars/web/login.clj
+++ b/src/clojars/web/login.clj
@@ -15,7 +15,7 @@
 
     (when login_failed
       [:div [:p.error "Incorrect username and/or password."]
-       [:p.hint "If you have not logged in since "
+       [:p.hint "If you have not logged in since April 2012 when "
         [:a {:href "https://groups.google.com/group/clojure/browse_thread/thread/5e0d48d2b82df39b"}
          "the insecure password hashes were wiped"]
         ", please use the " [:a {:href "/forgot-password"} "forgot password"]

--- a/src/clojars/web/user.clj
+++ b/src/clojars/web/user.clj
@@ -124,7 +124,7 @@
   (html-doc "Forgot password or username?" {}
     [:div.small-section
      [:h1 "Forgot something?"]
-     [:p "Don't worry, it happens to the best of us. Enter your email or username below, and we'll set you a password reset link, along with your username."]
+     [:p "Don't worry, it happens to the best of us. Enter your email or username below, and we'll send you a password reset link along with your username."]
      (form-to [:post "/forgot-password"]
               (label :email-or-username "Email or Username")
               (text-field {:placeholder "bob"

--- a/test/clojars/test/integration/sessions.clj
+++ b/test/clojars/test/integration/sessions.clj
@@ -21,7 +21,7 @@
       (follow-redirect)
       (has (status? 200))
       (within [:div :p.error]
-              (has (text? "Incorrect username and/or password.")))))
+              (has (text? "Incorrect username and/or password.Make sure that you are using your username, and not your email to log in.")))))
 
 (deftest user-can-login-and-logout
   (let [app (help/app)]


### PR DESCRIPTION
Email logins are now disabled, this change will warn users when they try to login with an email address. This change also makes the wiped hashes login message more informative about when it happened so people can work out if it applies to them or not.

I upgraded to Clojure 1.8 because it contains a handy new string function.