### PR TITLE
Add metadata for search engines

### DIFF
--- a/resources/security.html
+++ b/resources/security.html
@@ -1,4 +1,11 @@
 <div class="small-section">
+  <script type="application/ld+json">
+    {"@context":"http://schema.org",
+     "@type":"BreadcrumbList",
+     "itemListElement":[{"@type":"ListItem",
+                         "position":1,
+                         "item":{"@id":"https://clojars.org/security","name":"Security"}}]}
+  </script>
   <h1>Found a security flaw?</h1>
 
 

--- a/src/clojars/stats.clj
+++ b/src/clojars/stats.clj
@@ -3,7 +3,8 @@
             [com.stuartsierra.component :as component])
   (:import java.io.PushbackReader
            java.nio.file.Files
-           java.nio.file.LinkOption))
+           java.nio.file.LinkOption
+           (java.text DecimalFormat)))
 
 (defprotocol Stats
   (download-count
@@ -61,3 +62,6 @@
   (map->FileStats {:path-factory #(.getPath %
                                             (str stats-dir "/all.edn")
                                             (make-array String 0))}))
+
+(defn format-stats [num]
+  (.format (DecimalFormat. "#,##0") num))

--- a/src/clojars/web/browse.clj
+++ b/src/clojars/web/browse.clj
@@ -11,7 +11,7 @@
   (let [project-count (count-all-projects db)
         total-pages (-> (/ project-count per-page) Math/ceil .intValue)
         projects (browse-projects db page per-page)]
-    (html-doc "All projects" {:account account}
+    (html-doc "All projects" {:account account :description "Browse all of the projects in Clojars"}
      [:div.light-article.row
       [:h1 "All projects"]
       [:div.small-section

--- a/src/clojars/web/browse.clj
+++ b/src/clojars/web/browse.clj
@@ -5,7 +5,8 @@
             [clojars.db :refer [browse-projects count-all-projects
                                 count-projects-before]]
             [hiccup.form :refer [label submit-button text-field submit-button]]
-            [ring.util.response :refer [redirect]]))
+            [ring.util.response :refer [redirect]]
+            [clojars.web.structured-data :as structured-data]))
 
 (defn browse-page [db account page per-page]
   (let [project-count (count-all-projects db)
@@ -13,6 +14,7 @@
         projects (browse-projects db page per-page)]
     (html-doc "All projects" {:account account :description "Browse all of the projects in Clojars"}
      [:div.light-article.row
+      (structured-data/breadcrumbs [{:name "All projects" :url "https://clojars.org/projects"}])
       [:h1 "All projects"]
       [:div.small-section
        [:form.browse-from {:method :get :action "/projects"}

--- a/src/clojars/web/common.clj
+++ b/src/clojars/web/common.clj
@@ -5,13 +5,18 @@
             [clojars.web.safe-hiccup :refer [html5 raw form-to]]
             [clojars.web.helpers :as helpers]
             [clojure.string :refer [join]]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
 
 (defn when-ie [& contents]
   (str
    "<!--[if lt IE 9]>"
    (html contents)
    "<![endif]-->"))
+
+(defn meta-description [ctx]
+  (when-not (str/blank? (:description ctx))
+    [:meta {:name "description" :content (:description ctx)}]))
 
 (def footer
   [:footer.row
@@ -88,6 +93,7 @@
             :rel "icon"}]
     [:meta {:charset "utf-8"}]
     [:meta {:name "viewport" :content "width=device-width,initial-scale=1"}]
+    (meta-description ctx)
     [:title
      (when title
        (str title " - "))
@@ -156,6 +162,7 @@
 
     [:meta {:charset "utf-8"}]
     [:meta {:name "viewport" :content "width=device-width,initial-scale=1"}]
+    (meta-description ctx)
     [:title
      (when title
        (str title " - "))

--- a/src/clojars/web/common.clj
+++ b/src/clojars/web/common.clj
@@ -6,7 +6,8 @@
             [clojars.web.helpers :as helpers]
             [clojure.string :refer [join]]
             [clojure.java.io :as io]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [clojars.web.structured-data :as structured-data]))
 
 (defn when-ie [& contents]
   (str
@@ -14,9 +15,6 @@
    (html contents)
    "<![endif]-->"))
 
-(defn meta-description [ctx]
-  (when-not (str/blank? (:description ctx))
-    [:meta {:name "description" :content (:description ctx)}]))
 
 (def footer
   [:footer.row
@@ -93,7 +91,7 @@
             :rel "icon"}]
     [:meta {:charset "utf-8"}]
     [:meta {:name "viewport" :content "width=device-width,initial-scale=1"}]
-    (meta-description ctx)
+    (structured-data/meta-tags (assoc ctx :title title)) ;; TODO: talk about whether we should refactor signature of html-doc
     [:title
      (when title
        (str title " - "))
@@ -162,7 +160,7 @@
 
     [:meta {:charset "utf-8"}]
     [:meta {:name "viewport" :content "width=device-width,initial-scale=1"}]
-    (meta-description ctx)
+    (structured-data/meta-tags (assoc ctx :title title))
     [:title
      (when title
        (str title " - "))

--- a/src/clojars/web/common.clj
+++ b/src/clojars/web/common.clj
@@ -243,8 +243,13 @@
     (str "/" (:jar_name jar))
     (str "/" (:group_name jar) "/" (:jar_name jar))))
 
+(defn group-is-name?
+  "Is the group of the artifact the same as its name?"
+  [jar]
+  (= (:group_name jar) (:jar_name jar)))
+
 (defn jar-name [jar]
-  (if (= (:group_name jar) (:jar_name jar))
+  (if (group-is-name? jar)
     (:jar_name jar)
     (str (:group_name jar) "/" (:jar_name jar))))
 

--- a/src/clojars/web/dashboard.clj
+++ b/src/clojars/web/dashboard.clj
@@ -3,7 +3,10 @@
             [clojars.db :refer [jars-by-username find-groupnames recent-jars]]
             [clojars.stats :as stats]
             [hiccup.element :refer [unordered-list link-to]]
-            [clojars.web.helpers :as helpers]))
+            [clojars.web.safe-hiccup :as hiccup]
+            [hiccup.util :as util]
+            [clojars.web.helpers :as helpers]
+            [cheshire.core :as json]))
 
 (defn recent-jar [stats jar-map]
   (let [description (:description jar-map)
@@ -20,8 +23,25 @@
                                                                    (:group_name jar-map)
                                                                    (:jar_name jar-map))]]]))
 
+(def site-link-search-box
+  "This is used by Google and other search engines to display a search box
+  in search results for Clojars. It is only needed on the home page.
+  See https://developers.google.com/structured-data/slsb-overview for more info."
+  (hiccup/raw
+    (str "<script type=\"application/ld+json\">"
+         (json/generate-string
+           {"@context" "http://schema.org"
+            "@type"    "WebSite"
+            "url"      "https://clojars.org"
+            "potentialAction"
+                       {"@type"       "SearchAction"
+                        "target"      "https://clojars.org/search?q={search_term_string}"
+                        "query-input" "required name=search_term_string"}})
+         "</script>")))
+
 (defn index-page [db stats account]
   (html-doc-with-large-header nil {:account account}
+    site-link-search-box
     [:article.row
      (helpers/select-text-script)
      [:div.push-information.col-md-6.col-lg-6.col-sm-6.col-xs-12

--- a/src/clojars/web/dashboard.clj
+++ b/src/clojars/web/dashboard.clj
@@ -1,12 +1,10 @@
 (ns clojars.web.dashboard
   (:require [clojars.web.common :refer [html-doc html-doc-with-large-header jar-link group-link tag]]
+            [clojars.web.structured-data :as structured-data]
             [clojars.db :refer [jars-by-username find-groupnames recent-jars]]
             [clojars.stats :as stats]
             [hiccup.element :refer [unordered-list link-to]]
-            [clojars.web.safe-hiccup :as hiccup]
-            [hiccup.util :as util]
-            [clojars.web.helpers :as helpers]
-            [cheshire.core :as json]))
+            [clojars.web.helpers :as helpers]))
 
 (defn recent-jar [stats jar-map]
   (let [description (:description jar-map)
@@ -23,25 +21,11 @@
                                                                    (:group_name jar-map)
                                                                    (:jar_name jar-map))]]]))
 
-(def site-link-search-box
-  "This is used by Google and other search engines to display a search box
-  in search results for Clojars. It is only needed on the home page.
-  See https://developers.google.com/structured-data/slsb-overview for more info."
-  (hiccup/raw
-    (str "<script type=\"application/ld+json\">"
-         (json/generate-string
-           {"@context" "http://schema.org"
-            "@type"    "WebSite"
-            "url"      "https://clojars.org"
-            "potentialAction"
-                       {"@type"       "SearchAction"
-                        "target"      "https://clojars.org/search?q={search_term_string}"
-                        "query-input" "required name=search_term_string"}})
-         "</script>")))
 
 (defn index-page [db stats account]
   (html-doc-with-large-header nil {:account account}
-    site-link-search-box
+    structured-data/website
+    structured-data/organisation
     [:article.row
      (helpers/select-text-script)
      [:div.push-information.col-md-6.col-lg-6.col-sm-6.col-xs-12

--- a/src/clojars/web/dashboard.clj
+++ b/src/clojars/web/dashboard.clj
@@ -17,9 +17,10 @@
        (if (> (count description) truncate-length)
          (str (subs description 0 truncate-length) "...")
          description)]
-      [:p.hint.total-downloads "Downloads: " (stats/download-count stats
-                                                                   (:group_name jar-map)
-                                                                   (:jar_name jar-map))]]]))
+      [:p.hint.total-downloads "Downloads: " (-> (stats/download-count stats
+                                                                       (:group_name jar-map)
+                                                                       (:jar_name jar-map))
+                                                 (stats/format-stats))]]]))
 
 
 (defn index-page [db stats account]

--- a/src/clojars/web/dashboard.clj
+++ b/src/clojars/web/dashboard.clj
@@ -23,7 +23,8 @@
 
 
 (defn index-page [db stats account]
-  (html-doc-with-large-header nil {:account account}
+  (html-doc-with-large-header nil {:account account
+                                   :description "Clojars is a dead easy community repository for open source Clojure libraries."}
     structured-data/website
     structured-data/organisation
     [:article.row

--- a/src/clojars/web/group.clj
+++ b/src/clojars/web/group.clj
@@ -4,11 +4,14 @@
             [clojars.auth :refer [authorized?]]
             [hiccup.element :refer [unordered-list]]
             [hiccup.form :refer [text-field submit-button]]
-            [clojars.web.safe-hiccup :refer [form-to]]))
+            [clojars.web.safe-hiccup :refer [form-to]]
+            [clojars.web.structured-data :as structured-data]))
 
 (defn show-group [db account groupname membernames & errors]
   (html-doc (str groupname " group") {:account account :description (format "Clojars projects in the %s group" groupname)}
     [:div.small-section.col-md-6.col-lg-6.col-sm-6.col-xs-12
+     (structured-data/breadcrumbs [{:url  (str "https://clojars.org/groups/" groupname)
+                                    :name groupname}])
      [:h1 (str groupname " group")]
      [:h2 "Projects"]
      (unordered-list (map jar-link (jars-by-groupname db groupname)))

--- a/src/clojars/web/group.clj
+++ b/src/clojars/web/group.clj
@@ -7,7 +7,7 @@
             [clojars.web.safe-hiccup :refer [form-to]]))
 
 (defn show-group [db account groupname membernames & errors]
-  (html-doc (str groupname " group") {:account account}
+  (html-doc (str groupname " group") {:account account :description (format "Clojars projects in the %s group" groupname)}
     [:div.small-section.col-md-6.col-lg-6.col-sm-6.col-xs-12
      [:h1 (str groupname " group")]
      [:h2 "Projects"]

--- a/src/clojars/web/jar.clj
+++ b/src/clojars/web/jar.clj
@@ -11,7 +11,6 @@
             [clojars.auth :refer [authorized?]]
             [clojars.db :refer [find-jar jar-exists]]
             [clojars.stats :as stats]
-            [clojure.set :as set]
             [ring.util.codec :refer [url-encode]]
             [cheshire.core :as json]
             [clojars.web.helpers :as helpers]))
@@ -56,116 +55,124 @@
     single-fork-notice))
 
 (defn show-jar [db reporter stats account jar recent-versions count]
-  (html-doc (str (:jar_name jar) " " (:version jar)) {:account account :description (format "%s - %s" (:description jar) (:version jar))}
-            (let [pom-map (jar-to-pom-map reporter jar)]
-              [:div.light-article.row
-               (helpers/select-text-script)
-               [:div#jar-title.col-sm-9.col-lg-9.col-xs-12.col-md-9
-                [:h1 (jar-link jar)]
-                [:p.description (:description jar)]
-                [:ul#jar-info-bar.row
-                 [:li.col-md-4.col-sm-4.col-xs-12.col-lg-4
-                  (if-let [gh-info (github-info pom-map)]
-                    (link-to {:target "_blank"}
-                             (format "https://github.com/%s" gh-info)
-                             (helpers/retinized-image "/images/github-mark.png" "GitHub")
-                             gh-info)
-                    [:p.github
-                     (helpers/retinized-image "/images/github-mark.png" "GitHub")
-                     "N/A"])]
-                 [:li.col-md-4.col-sm-4.col-xs-12.col-lg-4
-                  (stats/download-count stats
-                                        (:group_name jar)
-                                        (:jar_name jar))
-                  " Downloads"]
-                 [:li.col-md-4.col-sm-4.col-xs-12.col-lg-4
-                  (stats/download-count stats
-                                        (:group_name jar)
-                                        (:jar_name jar)
-                                        (:version jar))
-                  " This Version"]]
-                (when-not pom-map
-                  [:p.error "Oops. We hit an error opening the metadata POM file for this project "
-                   "so some details are not available."])
-                [:h2 "Leiningen"]
-                [:div#leiningen-coordinates.package-config-example
-                 {:onClick "selectText('leiningen-coordinates');"}
-                 [:pre
-                  (tag "[")
-                  (jar-name jar)
-                  [:span.string " \""
-                   (:version jar) "\""] (tag "]") ]]
+  (let [total-downloads (-> (stats/download-count stats
+                                                  (:group_name jar)
+                                                  (:jar_name jar))
+                            (stats/format-stats))
+        downloads-this-version (-> (stats/download-count stats
+                                                         (:group_name jar)
+                                                         (:jar_name jar)
+                                                         (:version jar))
+                                   (stats/format-stats))]
+    (html-doc (str (:jar_name jar) " " (:version jar)) {:account account :description (format "%s - %s" (:description jar) (:version jar))
+                                                        :label1 "Downloads total/this version"
+                                                        :data1 (format "%s/%s" total-downloads downloads-this-version)
+                                                        :label2 "Coordinates"
+                                                        :data2 (format "[%s \"%s\"]" (jar-name jar) (:version jar))}
+      (let [pom-map (jar-to-pom-map reporter jar)]
+        [:div.light-article.row
+         (helpers/select-text-script)
+         [:div#jar-title.col-sm-9.col-lg-9.col-xs-12.col-md-9
+          [:h1 (jar-link jar)]
+          [:p.description (:description jar)]
+          [:ul#jar-info-bar.row
+           [:li.col-md-4.col-sm-4.col-xs-12.col-lg-4
+            (if-let [gh-info (github-info pom-map)]
+              (link-to {:target "_blank"}
+                       (format "https://github.com/%s" gh-info)
+                       (helpers/retinized-image "/images/github-mark.png" "GitHub")
+                       gh-info)
+              [:p.github
+               (helpers/retinized-image "/images/github-mark.png" "GitHub")
+               "N/A"])]
+           [:li.col-md-4.col-sm-4.col-xs-12.col-lg-4
+            total-downloads
+            " Downloads"]
+           [:li.col-md-4.col-sm-4.col-xs-12.col-lg-4
+            downloads-this-version
+            " This Version"]]
+          (when-not pom-map
+            [:p.error "Oops. We hit an error opening the metadata POM file for this project "
+             "so some details are not available."])
+          [:h2 "Leiningen"]
+          [:div#leiningen-coordinates.package-config-example
+           {:onClick "selectText('leiningen-coordinates');"}
+           [:pre
+            (tag "[")
+            (jar-name jar)
+            [:span.string " \""
+             (:version jar) "\""] (tag "]")]]
 
-                [:h2 "Gradle"]
-                [:div#gradle-coordinates.package-config-example
-                 {:onClick "selectText('gradle-coordinates');"}
-                 [:pre
-                  "compile "
-                  [:span.string
-                   \"
-                   (:group_name jar)
-                   ":"
-                   (:jar_name jar)
-                   ":"
-                   (:version jar)
-                   \"]]]
+          [:h2 "Gradle"]
+          [:div#gradle-coordinates.package-config-example
+           {:onClick "selectText('gradle-coordinates');"}
+           [:pre
+            "compile "
+            [:span.string
+             \"
+             (:group_name jar)
+             ":"
+             (:jar_name jar)
+             ":"
+             (:version jar)
+             \"]]]
 
-                [:h2 "Maven"]
-                [:div#maven-coordinates.package-config-example
-                 {:onClick "selectText('maven-coordinates');"}
-                 [:pre
-                  (tag "<dependency>\n")
-                  (tag "  <groupId>") (:group_name jar) (tag "</groupId>\n")
-                  (tag "  <artifactId>") (:jar_name jar) (tag "</artifactId>\n")
-                  (tag "  <version>") (:version jar) (tag "</version>\n")
-                  (tag "</dependency>")]]
-                (list
-                 (fork-notice jar))]
-               [:ul#jar-sidebar.col-sm-3.col-xs-12.col-md-3.col-lg-3
-                [:li
-                 [:h4 "Pushed by"]
-                 (user-link (:user jar)) " on "
-                 [:span {:title (str (java.util.Date. (:created jar)))} (simple-date (:created jar))]
-                 (if-let [url (commit-url pom-map)]
-                   [:span.commit-url " with " (link-to url "this commit")])]
-                [:li
-                 [:h4 "Recent Versions"]
-                 [:ul#versions
-                  (for [v recent-versions]
-                    [:li (link-to (url-for (assoc jar
-                                             :version (:version v)))
-                                  (:version v))])]
-                 ;; by default, 5 versions are shown. If there are only 5 to
-                 ;; see, then there's no reason to show the 'all versions' link
-                 (when (> count 5)
-                   [:p (link-to (str (jar-url jar) "/versions")
-                                (str "Show All Versions (" count " total)"))])]
-                (let [dependencies
-                      (dependency-section db "Dependencies" "dependencies"
-                                          (remove #(not= (:scope %) "compile") (:dependencies pom-map)))]
-                  (when-not (empty? dependencies)
-                    [:li dependencies]))
-                (when-let [homepage (:homepage jar)]
-                  [:li.homepage
-                   [:h4 "Homepage"]
-                   (safe-link-to homepage homepage)])
-                (when-let [licenses (seq (:licenses pom-map))]
-                  [:li.license
-                   [:h4 "License"]
-                   [:ul#licenses
-                    (for [{:keys [name url]} licenses]
-                      [:li (safe-link-to url name)])]])
-                [:li
-                 [:h4 "Version Badge"]
-                 [:p
-                  "Want to display the "
-                  (link-to {:target "_blank"} (version-badge-url jar) "latest version")
-                  " of your project on Github? Use the markdown code below!"]
-                 [:textarea#version-badge
-                  {:readonly "readonly" :rows 4 :onClick "selectText('version-badge')"}
-                  (badge-markdown jar)]
-                 ]
-                ]])))
+          [:h2 "Maven"]
+          [:div#maven-coordinates.package-config-example
+           {:onClick "selectText('maven-coordinates');"}
+           [:pre
+            (tag "<dependency>\n")
+            (tag "  <groupId>") (:group_name jar) (tag "</groupId>\n")
+            (tag "  <artifactId>") (:jar_name jar) (tag "</artifactId>\n")
+            (tag "  <version>") (:version jar) (tag "</version>\n")
+            (tag "</dependency>")]]
+          (list
+            (fork-notice jar))]
+         [:ul#jar-sidebar.col-sm-3.col-xs-12.col-md-3.col-lg-3
+          [:li
+           [:h4 "Pushed by"]
+           (user-link (:user jar)) " on "
+           [:span {:title (str (java.util.Date. (:created jar)))} (simple-date (:created jar))]
+           (if-let [url (commit-url pom-map)]
+             [:span.commit-url " with " (link-to url "this commit")])]
+          [:li
+           [:h4 "Recent Versions"]
+           [:ul#versions
+            (for [v recent-versions]
+              [:li (link-to (url-for (assoc jar
+                                       :version (:version v)))
+                            (:version v))])]
+           ;; by default, 5 versions are shown. If there are only 5 to
+           ;; see, then there's no reason to show the 'all versions' link
+           (when (> count 5)
+             [:p (link-to (str (jar-url jar) "/versions")
+                          (str "Show All Versions (" count " total)"))])]
+          (let [dependencies
+                (dependency-section db "Dependencies" "dependencies"
+                                    (remove #(not= (:scope %) "compile") (:dependencies pom-map)))]
+            (when-not (empty? dependencies)
+              [:li dependencies]))
+          (when-let [homepage (:homepage jar)]
+            [:li.homepage
+             [:h4 "Homepage"]
+             (safe-link-to homepage homepage)])
+          (when-let [licenses (seq (:licenses pom-map))]
+            [:li.license
+             [:h4 "License"]
+             [:ul#licenses
+              (for [{:keys [name url]} licenses]
+                [:li (safe-link-to url name)])]])
+          [:li
+           [:h4 "Version Badge"]
+           [:p
+            "Want to display the "
+            (link-to {:target "_blank"} (version-badge-url jar) "latest version")
+            " of your project on Github? Use the markdown code below!"]
+           [:textarea#version-badge
+            {:readonly "readonly" :rows 4 :onClick "selectText('version-badge')"}
+            (badge-markdown jar)]
+           ]
+          ]]))))
 
 (defn show-versions [account jar versions]
   (html-doc (str "all versions of "(jar-name jar)) {:account account}

--- a/src/clojars/web/jar.clj
+++ b/src/clojars/web/jar.clj
@@ -56,7 +56,7 @@
     single-fork-notice))
 
 (defn show-jar [db reporter stats account jar recent-versions count]
-  (html-doc (str (:jar_name jar) " " (:version jar)) {:account account}
+  (html-doc (str (:jar_name jar) " " (:version jar)) {:account account :description (format "%s - %s" (:description jar) (:version jar))}
             (let [pom-map (jar-to-pom-map reporter jar)]
               [:div.light-article.row
                (helpers/select-text-script)

--- a/src/clojars/web/search.clj
+++ b/src/clojars/web/search.clj
@@ -31,9 +31,9 @@
                   {:error (format "Invalid search syntax for query `%s`" query)}))))))
 
 (defn html-search [search account query page]
-  (html-doc (str query " - search") {:account account :query query}
+  (html-doc (str query " - search") {:account account :query query :description (format "Clojars search results for '%s'" query)}
     [:div.light-article.row
-     [:h1 "Search for '" query "'"]
+     [:h1 (format "Search for '%s'" query)]
      (try
        (let [results (search/search search query page)
              {:keys [total-hits results-per-page offset]} (meta results)]

--- a/src/clojars/web/structured_data.clj
+++ b/src/clojars/web/structured_data.clj
@@ -1,0 +1,34 @@
+(ns clojars.web.structured-data
+  "Central place for providing all structured data to search engines and crawlers
+  See https://developers.google.com/structured-data/"
+  (:require [cheshire.core :as json]
+            [clojars.web.safe-hiccup :as hiccup]))
+
+(def common "Common ld-json attributes"
+  {"@context" "http://schema.org"
+   "url"      "https://clojars.org"})
+
+(defn ld-json
+  "Takes a map m, converts it to JSON, and puts it inside
+  an application/ld+json script tag."
+  [m]
+  (hiccup/raw
+    (str "<script type=\"application/ld+json\">"
+         (json/generate-string (merge common m))
+         "</script>")))
+
+(def website
+  (ld-json
+    {"@type"  "WebSite"
+     "name"   "Clojars" ;; https://developers.google.com/structured-data/site-name
+     "sameAs" ["https://twitter.com/clojars"] ;; https://developers.google.com/structured-data/customize/social-profiles
+     "potentialAction" ;; https://developers.google.com/structured-data/slsb-overview
+              {"@type"       "SearchAction"
+               "target"      "https://clojars.org/search?q={search_term_string}"
+               "query-input" "required name=search_term_string"}}))
+
+(def organisation
+  (ld-json
+    {"@type" "Organization"
+     "name"  "Clojars"
+     "logo"  "https://clojars.org/images/clojars-logo@2x.png"}))

--- a/src/clojars/web/structured_data.clj
+++ b/src/clojars/web/structured_data.clj
@@ -6,8 +6,7 @@
             [clojure.string :as str]))
 
 (def common "Common ld-json attributes"
-  {"@context" "http://schema.org"
-   "url"      "https://clojars.org"})
+  {"@context" "http://schema.org"})
 
 (defn ld-json
   "Takes a map m, converts it to JSON, and puts it inside
@@ -21,6 +20,7 @@
 (def website
   (ld-json
     {"@type"  "WebSite"
+     "url"    "https://clojars.org"
      "name"   "Clojars" ;; https://developers.google.com/structured-data/site-name
      "sameAs" ["https://twitter.com/clojars"] ;; https://developers.google.com/structured-data/customize/social-profiles
      "potentialAction" ;; https://developers.google.com/structured-data/slsb-overview
@@ -31,6 +31,7 @@
 (def organisation
   (ld-json
     {"@type" "Organization"
+     "url"   "https://clojars.org"
      "name"  "Clojars"
      "logo"  "https://clojars.org/images/clojars-logo@2x.png"}))
 
@@ -72,3 +73,13 @@
     (meta-property "og:title" (:title ctx))
     (meta-property "og:description" (:description ctx))
     (meta-property "og:image" (or (:image-url ctx) "https://clojars.org/images/clojars-logo@2x.png"))))
+
+(defn breadcrumbs [crumbs]
+  (ld-json
+    {"@type"           "BreadcrumbList"
+     "itemListElement" (into [] (map-indexed (fn [index crumb]
+                                               {"@type"    "ListItem"
+                                                "position" (inc index)
+                                                "item"     {"@id"  (:url crumb)
+                                                            "name" (:name crumb)}}))
+                             crumbs)}))

--- a/src/clojars/web/structured_data.clj
+++ b/src/clojars/web/structured_data.clj
@@ -2,7 +2,8 @@
   "Central place for providing all structured data to search engines and crawlers
   See https://developers.google.com/structured-data/"
   (:require [cheshire.core :as json]
-            [clojars.web.safe-hiccup :as hiccup]))
+            [clojars.web.safe-hiccup :as hiccup]
+            [clojure.string :as str]))
 
 (def common "Common ld-json attributes"
   {"@context" "http://schema.org"
@@ -32,3 +33,42 @@
     {"@type" "Organization"
      "name"  "Clojars"
      "logo"  "https://clojars.org/images/clojars-logo@2x.png"}))
+
+(defn meta-property
+  "Return a meta tag if content is provided"
+  [property content]
+  (when-not (str/blank? content)
+    [:meta {:property property :content content}]))
+
+(defn meta-name
+  "Return a meta tag if content is provided"
+  [name content]
+  (when-not (str/blank? content)
+    [:meta {:name name :content content}]))
+
+(defn meta-tags
+  "Returns meta tags for description, twitter cards, and facebook opengraph."
+  [ctx]
+  (list
+    ;; meta description
+    (meta-name "description" (:description ctx))
+
+    ;; twitter metadata
+    [:meta {:name "twitter:card" :content "summary"}]
+    [:meta {:name "twitter:site:id" :content "@clojars"}]
+    [:meta {:name "twitter:site" :content "https://clojars.org"}]
+    (meta-name "twitter:title" (:title ctx))
+    (meta-name "twitter:description" (:description ctx))
+    (meta-name "twitter:image" (or (:image-url ctx) "https://clojars.org/images/clojars-logo@2x.png"))
+    (meta-name "twitter:label1" (:label1 ctx))
+    (meta-name "twitter:data1" (:data1 ctx))
+    (meta-name "twitter:label2" (:label2 ctx))
+    (meta-name "twitter:data2" (:data2 ctx))
+
+    ;; facebook opengraph metadata
+    [:meta {:property "og:type" :content "website"}]
+    [:meta {:property "og:site_name" :content "Clojars"}]
+    (meta-property "og:url" (:url ctx))
+    (meta-property "og:title" (:title ctx))
+    (meta-property "og:description" (:description ctx))
+    (meta-property "og:image" (or (:image-url ctx) "https://clojars.org/images/clojars-logo@2x.png"))))

--- a/test/clojars/test/unit/stats.clj
+++ b/test/clojars/test/unit/stats.clj
@@ -37,7 +37,7 @@
     (Files/createDirectory (.getPath fs dir (make-array String 0))
                            (make-array FileAttribute 0))
     (Files/write (.getPath fs dir (into-array String ["all.edn"]))
-                 (.getBytes string)             
+                 (.getBytes string)
                  (make-array OpenOption 0))
     fs))
 
@@ -63,3 +63,12 @@
       ;; TODO test cache expiration
       (finally
         (component/stop stats)))))
+
+(deftest format-stats-with-commas
+  (is "0" (format-stats 0))
+  (is "1" (format-stats 1))
+  (is "-1" (format-stats -1))
+  (is "1" (format-stats 1.25129))
+  (is "999" (format-stats 999))
+  (is "1,000" (format-stats 1000))
+  (is "2,123,512" (format-stats 2123512)))

--- a/test/clojars/test/unit/web/structured_data.clj
+++ b/test/clojars/test/unit/web/structured_data.clj
@@ -1,0 +1,18 @@
+(ns clojars.test.unit.web.structured-data
+  (:require [clojure.test :refer :all]
+            [clojars.web.structured-data :refer :all]))
+
+(deftest meta-name-test
+  (is (nil? (meta-name "description" "")))
+  (is (= [:meta {:name "description" :content "desc"}] (meta-name "description" "desc"))))
+
+(deftest meta-property-test
+  (is (nil? (meta-property "description" "")))
+  (is (= [:meta {:name "description" :content "desc"}] (meta-name "description" "desc"))))
+
+(deftest breadcrumbs-test
+  (is (= "<script type=\"application/ld+json\">{\"@context\":\"http://schema.org\",\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"item\":{\"@id\":\"https://clojars.org/groups/sky\",\"name\":\"sky\"}},{\"@type\":\"ListItem\",\"position\":2,\"item\":{\"@id\":\"https://clojars.org/sky/high\",\"name\":\"high\"}}]}</script>"
+         (.to-str (breadcrumbs [{:url  "https://clojars.org/groups/sky"
+                                 :name "sky"}
+                                {:url  "https://clojars.org/sky/high"
+                                 :name "high"}])))))


### PR DESCRIPTION
- [x] [meta](http://www.wordstream.com/meta-tags) description and other meta tags
- [x] [breadcrumbs](https://developers.google.com/structured-data/breadcrumbs) (also need to provide breadcrumbs back to org
- [x] [show site name](https://developers.google.com/structured-data/site-name)
- [x] [sitelinks search box](https://developers.google.com/structured-data/slsb-overview)
- [x] Social profiles
- [x] [structured data](https://developers.google.com/structured-data/)
- [x] open graph/twitter card metadata

https://developers.google.com/structured-data/

Relates to #464