### PR TITLE
Force typekit to use https

### DIFF
--- a/src/clojars/web/common.clj
+++ b/src/clojars/web/common.clj
@@ -103,7 +103,7 @@
          ;; (then the default colors were removed)
          ;; more info: http://getbootstrap.com/css/#grid
          ["reset.css" "vendor/bootstrap/bootstrap.css" "screen.css"])
-    (include-js "//use.typekit.net/zhw0tse.js")
+    (include-js "https://use.typekit.net/zhw0tse.js")
     (typekit-js)
     (google-analytics-js)
     (raw (when-ie (include-js "/js/html5.js")))]
@@ -174,7 +174,7 @@
          ;; (then the default colors were removed)
          ;; more info: http://getbootstrap.com/css/#grid
          ["reset.css" "vendor/bootstrap/bootstrap.css" "screen.css"])
-    (include-js "//use.typekit.net/zhw0tse.js")
+    (include-js "https://use.typekit.net/zhw0tse.js")
     (typekit-js)
     (google-analytics-js)
     (raw (when-ie (include-js "/js/html5.js")))]


### PR DESCRIPTION
closes clojars/clojars-web#496

A fairly simple fix. if there is anything that I have missed don't hesitate to mention it.
```
$ ag typekit
src/clojars/web/common.clj
80:(defn typekit-js []
81:  [:script "try{Typekit.load({async:true});}catch(e){}"])
106:    (include-js "https://use.typekit.net/zhw0tse.js")
107:    (typekit-js)
177:    (include-js "https://use.typekit.net/zhw0tse.js")
178:    (typekit-js)
```