### PR TITLE
Redirect trailing slash

### DIFF
--- a/src/clojars/middleware.clj
+++ b/src/clojars/middleware.clj
@@ -1,0 +1,17 @@
+(ns clojars.middleware)
+
+; Adapted from https://gist.github.com/dannypurcell/8215411
+(defn wrap-ignore-trailing-slash
+  "Modifies the request uri before calling the handler.
+  Removes a single trailing slash from the end of the uri if present.
+
+  Useful for handling optional trailing slashes until Compojure's route matching syntax supports regex.
+  Adapted from http://stackoverflow.com/questions/8380468/compojure-regex-for-matching-a-trailing-slash"
+  [handler]
+  (fn [request]
+    (let [uri (:uri request)]
+      (handler (assoc request :uri (if (and (not (= "/" uri))
+                                            (.endsWith uri "/"))
+                                     (subs uri 0 (dec (count uri)))
+                                     uri))))))
+

--- a/src/clojars/web.clj
+++ b/src/clojars/web.clj
@@ -8,7 +8,8 @@
              [config :refer [config]]
              [db :as db]
              [errors :refer [wrap-exceptions]]
-             [http-utils :refer [wrap-x-frame-options wrap-secure-session]]]
+             [http-utils :refer [wrap-x-frame-options wrap-secure-session]]
+             [middleware :refer [wrap-ignore-trailing-slash]]]
             [clojars.friend.registration :as registration]
             [clojars.routes
              [api :as api]
@@ -127,7 +128,8 @@
        (wrap-secure-session)
        (wrap-resource "public")
        (wrap-content-type)
-       (wrap-not-modified))))
+       (wrap-not-modified)
+       (wrap-ignore-trailing-slash))))
 
 (defn handler-optioned [{:keys [db error-reporter stats search mailer]}]
   (clojars-app (:spec db) error-reporter stats search mailer))

--- a/test/clojars/test/unit/middleware.clj
+++ b/test/clojars/test/unit/middleware.clj
@@ -1,0 +1,17 @@
+(ns clojars.test.unit.middleware
+  (:require [clojars.middleware :as middleware]
+            [clojure.test :refer :all]))
+
+(def trailing-slash (middleware/wrap-ignore-trailing-slash (fn [x] (get x :uri))))
+
+(deftest trailing-slash-doesnt-modify-root
+  (is (= "/" (trailing-slash {:uri "/"}))))
+
+(deftest trailing-slash-doesnt-modify-sub-routes
+  (is (= "/artifact/project") (trailing-slash {:uri "/artifact/project"})))
+
+(deftest trailing-slash-removes-trailing-slash
+  (is (= "/artifact/project") (trailing-slash {:uri "/artifact/project/"})))
+
+(deftest trailing-slash-doesnt-remove-redundant-trailing-slash
+  (is (= "/artifact/project/") (trailing-slash {:uri "/artifact/project//"})))


### PR DESCRIPTION
This is a fairly simple change too, took a little work seeing how you had structured the codebase.

the change is fairly simple, the code that was used can be found here: https://gist.github.com/dannypurcell/8215411

I initially wrote it according the the specification in #491, using a redirect and stripping off the trailing `/`.
This worked fine except in the pathological example of navigation to `/artifact/project/////////////` where the browser will actually complain about too many redirect loops. (this also has the potential to put unnecessary load on the server if I were to pass in a large url.

looking at how other sites do this, 
- we could just strip off all trailing `/`'s
- just show a 404 if there is more than one trailing `/` present.

currently the latter is implemented, get back to me if you think it needs a more comprehensive implementation.

Thanks.