### PR TITLE
increase clojars badge field size

### DIFF
--- a/src/clojars/web/jar.clj
+++ b/src/clojars/web/jar.clj
@@ -198,7 +198,7 @@
           (link-to {:target "_blank"} (version-badge-url jar) "latest version")
           " of your project on Github? Use the markdown code below!"]
          [:textarea#version-badge
-          {:readonly "readonly" :rows 4 :onClick "selectText('version-badge')"}
+          {:readonly "readonly" :rows 6 :onClick "selectText('version-badge')"}
           (badge-markdown jar)]]]])))
 
 (defn show-versions [account jar versions]


### PR DESCRIPTION
Make the textarea for Clojars badge url slightly bigger, so the url part of the markdown link is visible.