### PR TITLE
Suggest looking in maven central for some artifacts

### DIFF
--- a/resources/public/stylesheets/screen.css
+++ b/resources/public/stylesheets/screen.css
@@ -438,16 +438,17 @@ footer a {
 #flash {
   font-weight: bold;
   padding: 10px;
-  margin: 10px;
+  margin: 10px 0;
   border-radius: 10px;
 }
 
 #flash.info {
-      background-color: #ffb33b;
+  background-color: #ffb33b;
 }
 
 #flash.error {
-    background-color: #ff2929;
+  background-color: #ff2929;
+  color: #393536;
 }
 
 .error ul {

--- a/src/clojars/web/common.clj
+++ b/src/clojars/web/common.clj
@@ -226,9 +226,9 @@
     body
     (footer (get ctx :footer-links? true))]))
 
-(defn flash [msg]
-  (when msg
-    [:div#flash.info msg]))
+(defn flash [& msg]
+  (when (some some? msg)
+    (into [:div#flash.info] msg)))
 
 (defn error-list [errors]
   (when errors

--- a/src/clojars/web/search.clj
+++ b/src/clojars/web/search.clj
@@ -1,11 +1,14 @@
 (ns clojars.web.search
   (:require [clojars.web.common :refer [html-doc jar-link jar-fork?
                                         collection-fork-notice user-link
-                                        format-date page-nav]]
+                                        format-date page-nav flash]]
+            [hiccup.element :refer [link-to]]
+            [ring.util.codec :refer [url-encode]]
             [clojars.search :as search]
             [cheshire.core :as json]
             [clojars.errors :as errors]
-            [clojars.web.error-api :as error-api]))
+            [clojars.web.error-api :as error-api]
+            [clojure.string :as str]))
 
 (defn- jar->json [jar]
   (let [m {:jar_name (:artifact-id jar)
@@ -32,10 +35,65 @@
           :error-message (format "Invalid search syntax for query `%s`" query)}
          (errors/error-id))))))
 
+(defn split-query
+  "Tries to split a query into a group-id and artifact-id tuple"
+  [query]
+  (if (str/includes? query "/")
+    (->> (str/split query #"[\w\.]+\/")
+         (map str/lower-case))
+    [nil (str/lower-case query)]))
+
+(def maven-groups
+  #{"org.clojure"})
+
+(def org-clojure-artifacts
+  #{"clojure"
+    "clojurescript"
+    "core.async"
+    "tools.nrepl"
+    "java.jdbc"
+    "tools.logging"
+    "tools.namespace"
+    "clojure-contrib"})
+
+(def other-artifacts
+  ;eg {"simulant" "org.datomic"}
+  {})
+
+(def artifact-id->group-id
+  (->> org-clojure-artifacts
+       (map (fn [a] [a "org.clojure"]))
+       (into {})
+       (merge other-artifacts)))
+
+(defn on-maven-central
+  "Returns a tuple of group-id, artifact-id or false"
+  [query]
+  (let [[group-id artifact-id] (split-query query)]
+    (cond
+      (maven-groups group-id) [group-id artifact-id]
+      (artifact-id->group-id artifact-id) [(artifact-id->group-id artifact-id) artifact-id]
+      :default false)))
+
+(defn maven-search-link
+  ([group-id artifact-id]
+   (cond->> ""
+            group-id (str (format "g:\"%s\" " group-id))
+            artifact-id (str (format "a:\"%s\" " artifact-id))
+            true (str "|ga|1|")
+            true (url-encode)
+            true (str "http://search.maven.org/#search"))))
+
 (defn html-search [search account query page]
   (html-doc (str query " - search") {:account account :query query :description (format "Clojars search results for '%s'" query)}
     [:div.light-article.row
      [:h1 (format "Search for '%s'" query)]
+     (when-let [mvn-tuple (on-maven-central query)]
+       (flash "Given your search terms, you may also want to "
+              (link-to (apply maven-search-link mvn-tuple) "search Maven Central")
+              "."
+              [:br]
+              [:small "org.clojure artifacts are distributed via Maven Central instead of Clojars."]))
      (try
        (let [results (search/search search query page)
              {:keys [total-hits results-per-page offset]} (meta results)]


### PR DESCRIPTION
For a list of artifacts we know live in maven central
(org.clojure ones) we suggest going to maven central for
them.

This is pretty rough at the moment, still needs some styling (imo) 
![search for clojure](https://cloud.githubusercontent.com/assets/3586137/19017692/09ce72b8-88a0-11e6-82f7-73bdd5b569a9.png)
I'm looking for feedback around this, I was thinking of using something like [bootstrap's alerts](http://getbootstrap.com/components/#alerts) but I don't know if there is something like them used elsewhere on the site?

Also we should probably move the artifacts out to config somewhere rather than keeping them in code. Not sure if that is useful or not, is hot config reloading a thing that is done?

This fixes #480
