### PR TITLE
Escape queries before passing to lucene

### DIFF
--- a/src/clojars/search.clj
+++ b/src/clojars/search.clj
@@ -67,8 +67,8 @@
     (binding [clucy/*analyzer* analyzer]
       (let [[old] (try
                     (clucy/search index (format "artifact-id:%s AND group-id:%s"
-                                              (:artifact-id doc)
-                                              (:group-id doc)) 1)
+                                                (QueryParser/escape (:artifact-id doc))
+                                                (QueryParser/escape (:group-id doc))) 1)
                     (catch IndexNotFoundException _
                       ;; This happens when the index is searched before any data
                       ;; is added. We can treat it here as a nil return
@@ -76,8 +76,8 @@
         (if old
           (when (< (Long. (:at old)) (:at doc))
             (clucy/search-and-delete index (format "artifact-id:%s AND group-id:%s"
-                                                   (:artifact-id doc)
-                                                   (:group-id doc)))
+                                                   (QueryParser/escape (:artifact-id doc))
+                                                   (QueryParser/escape (:group-id doc))))
             (clucy/add index (with-meta doc field-settings)))
           (clucy/add index (with-meta doc field-settings)))))))
 
@@ -146,7 +146,7 @@
               parser (QueryParser. clucy/*version*
                                    "_content"
                                    clucy/*analyzer*)
-              query  (.parse parser query)
+              query  (.parse parser (QueryParser/escape query))
               query  (CustomScoreQuery. query (download-values stats))
               hits   (.search searcher query (* per-page page))
               highlighter (#'clucy/make-highlighter query searcher nil)]

--- a/src/clojars/search.clj
+++ b/src/clojars/search.clj
@@ -146,7 +146,7 @@
               parser (QueryParser. clucy/*version*
                                    "_content"
                                    clucy/*analyzer*)
-              query  (.parse parser (QueryParser/escape query))
+              query  (.parse parser query)
               query  (CustomScoreQuery. query (download-values stats))
               hits   (.search searcher query (* per-page page))
               highlighter (#'clucy/make-highlighter query searcher nil)]

--- a/src/clojars/search.clj
+++ b/src/clojars/search.clj
@@ -67,8 +67,8 @@
     (binding [clucy/*analyzer* analyzer]
       (let [[old] (try
                     (clucy/search index (format "artifact-id:%s AND group-id:%s"
-                                                (QueryParser/escape (:artifact-id doc))
-                                                (QueryParser/escape (:group-id doc))) 1)
+                                                (some-> doc :artifact-id (QueryParser/escape))
+                                                (some-> doc :group-id (QueryParser/escape))) 1)
                     (catch IndexNotFoundException _
                       ;; This happens when the index is searched before any data
                       ;; is added. We can treat it here as a nil return
@@ -76,8 +76,8 @@
         (if old
           (when (< (Long. (:at old)) (:at doc))
             (clucy/search-and-delete index (format "artifact-id:%s AND group-id:%s"
-                                                   (QueryParser/escape (:artifact-id doc))
-                                                   (QueryParser/escape (:group-id doc))))
+                                                   (some-> doc :artifact-id (QueryParser/escape))
+                                                   (some-> doc :group-id (QueryParser/escape))))
             (clucy/add index (with-meta doc field-settings)))
           (clucy/add index (with-meta doc field-settings)))))))
 

--- a/src/clojars/web/search.clj
+++ b/src/clojars/web/search.clj
@@ -7,8 +7,9 @@
             [clojars.search :as search]
             [cheshire.core :as json]
             [clojars.errors :as errors]
-            [clojars.web.error-api :as error-api]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [ring.util.codec :refer [url-encode]
+            [clojars.web.error-api :as error-api]]))
 
 (defn- jar->json [jar]
   (let [m {:jar_name (:artifact-id jar)
@@ -118,8 +119,9 @@
                                   [:td (format-date created)])]]])]
             (page-nav page
               (int (Math/ceil (/ total-hits results-per-page)))
-              :base-path (str "/search?q=" query "&page="))]))
-       (catch Exception _
+              :base-path (str "/search?q=" (url-encode query) "&page="))]))
+       (catch Exception e
+         (prn e)
          [:p "Could not search; please check your query syntax."]))]))
 
 (defn search [search account params]

--- a/src/clojars/web/search.clj
+++ b/src/clojars/web/search.clj
@@ -120,8 +120,7 @@
             (page-nav page
               (int (Math/ceil (/ total-hits results-per-page)))
               :base-path (str "/search?q=" (url-encode query) "&page="))]))
-       (catch Exception e
-         (prn e)
+       (catch Exception _
          [:p "Could not search; please check your query syntax."]))]))
 
 (defn search [search account params]

--- a/src/clojars/web/search.clj
+++ b/src/clojars/web/search.clj
@@ -8,8 +8,8 @@
             [cheshire.core :as json]
             [clojars.errors :as errors]
             [clojure.string :as str]
-            [ring.util.codec :refer [url-encode]
-            [clojars.web.error-api :as error-api]]))
+            [ring.util.codec :refer [url-encode]]
+            [clojars.web.error-api :as error-api]))
 
 (defn- jar->json [jar]
   (let [m {:jar_name (:artifact-id jar)


### PR DESCRIPTION
This will stop both indexing errors and the errors produced
by queries containing lucene keywords (eg. :, {}, -).

It will prevent users from being able to use some lucene queries,
and could be a breaking change as a result. I'm unsure
how much that functionality is used, however. If that
information can't be gleaned easily, we could use
[laboratory](https://github.com/yeller/laboratory) to run both side by side and see what happens.

If we wanted to continue supporting that use case, (#125, #324)
we could add an advanced mode, and possibly more directly
expose the errors that lucene query parsing throws?

This should fix #494 and #466