### PR TITLE
Issue 474 add padding

### DIFF
--- a/resources/public/stylesheets/screen.css
+++ b/resources/public/stylesheets/screen.css
@@ -517,7 +517,7 @@ footer a {
   /* reflow the 'hero' and 'getting started' text on small screens  */
   .getting-started > .col-md-12, .hero-text > .col-md-12 {
     display: inline;
-    padding: 0
+    padding: 0;
   }
 
   .small-header {

--- a/resources/public/stylesheets/screen.css
+++ b/resources/public/stylesheets/screen.css
@@ -520,6 +520,11 @@ footer a {
     padding: 0;
   }
 
+  /* slightly tweak padding of 'getting started' for better mobile legibility */
+  .getting-started {
+      padding: 0 25px;
+  }
+
   .small-header {
     padding-bottom: 90px;
   }


### PR DESCRIPTION
This PR addresses the issue https://github.com/clojars/clojars-web/issues/474.

I tried a few different approaches. Different bootstrap gird classes, additional media queries. Once I settled on simply using left/right padding I tried using `em` units like the rest of the project, but it didn't have a very pleasant result, so I ultimately fall back to good ol' pixels.  

Here are some before/after screen shots at various mobile breakpoints.

- iphone-6-plus-before
  ![iphone-6-plus-before](https://cloud.githubusercontent.com/assets/128298/19136126/e7b2a59c-8b37-11e6-9237-d5a4a976b1bb.png)

- iphone-6-plus-after
  ![iphone-6-plus-after](https://cloud.githubusercontent.com/assets/128298/19136158/2bf9c258-8b38-11e6-93fa-bb8f42969070.png)

- iphone-6-before
  ![iphone-6-before](https://cloud.githubusercontent.com/assets/128298/19136124/e7b19832-8b37-11e6-94ff-a913dbccc3f0.png)

- iphone-6-after
  ![iphone-6-after](https://cloud.githubusercontent.com/assets/128298/19136122/e7b1625e-8b37-11e6-99fb-0842a2ce7196.png)

- iphone-5-before
  ![iphone-5-before](https://cloud.githubusercontent.com/assets/128298/19136123/e7b145a8-8b37-11e6-967f-cd8c9b146e37.png)

- iphone-5-after
  ![iphone-5-after](https://cloud.githubusercontent.com/assets/128298/19136121/e7ae4baa-8b37-11e6-8e72-0c343f95faea.png)

