### PR TITLE
Issue 583: HTML improvements

### DIFF
--- a/src/clojars/web/jar.clj
+++ b/src/clojars/web/jar.clj
@@ -77,9 +77,10 @@
                                                          (:group_name jar)
                                                          (:jar_name jar)
                                                          (:version jar))
-                                   (stats/format-stats))]
+                                   (stats/format-stats))
+        title (format "[%s/%s \"%s\"]" (:group_name jar) (:jar_name jar) (:version jar))]
     (html-doc
-      (str (:jar_name jar) " " (:version jar)) {:account account :description (format "%s - %s" (:description jar) (:version jar))
+      title {:account account :description (format "%s %s" title (:description jar))
                                                 :label1  (str "Total downloads / this version")
                                                 :data1   (format "%s / %s" total-downloads downloads-this-version)
                                                 :label2  "Coordinates"

--- a/src/clojars/web/search.clj
+++ b/src/clojars/web/search.clj
@@ -85,7 +85,7 @@
             true (str "http://search.maven.org/#search"))))
 
 (defn html-search [search account query page]
-  (html-doc (str query " - search") {:account account :query query :description (format "Clojars search results for '%s'" query)}
+  (html-doc (str query " - search - page " page) {:account account :query query :description (format "Clojars search results page %d for '%s'" page query)}
     [:div.light-article.row
      [:h1 (format "Search for '%s'" query)]
      (when-let [mvn-tuple (on-maven-central query)]

--- a/src/clojars/web/structured_data.clj
+++ b/src/clojars/web/structured_data.clj
@@ -47,12 +47,18 @@
   (when-not (str/blank? content)
     [:meta {:name name :content content}]))
 
+(defn limit-size
+  [s n] 
+ (if (> (count s) n)
+   (str (subs s 0 (- n 3)) "...")
+   s))
+
 (defn meta-tags
   "Returns meta tags for description, twitter cards, and facebook opengraph."
   [ctx]
   (list
     ;; meta description
-    (meta-name "description" (:description ctx))
+    (meta-name "description" (limit-size (:description ctx) 150))
 
     ;; twitter metadata
     [:meta {:name "twitter:card" :content "summary"}]


### PR DESCRIPTION
This is about issue #583, improving on title and metadata of pages as suggested.

Long meta descriptions: Limited to 150 characters recommended.

Duplicate meta descriptions and title: Including group, artifact and version following lein coordinate style.

Not sure how to handle short meta description, it is recommended to have at least 60 characters.