### PR TITLE
Issue 125: Document search syntax guide

### DIFF
--- a/resources/public/stylesheets/screen.css
+++ b/resources/public/stylesheets/screen.css
@@ -236,6 +236,10 @@ footer a {
   margin: 50px 0;
 }
 
+.search-form-container > form > .col-md-12 {
+  color: #717171;
+}
+
 #content-wrapper {
   background: white;
   margin: 0 -15px;

--- a/src/clojars/web/common.clj
+++ b/src/clojars/web/common.clj
@@ -211,7 +211,11 @@
                 :required true}]
        [:input {:id "search-button"
                 :value "Search"
-                :type "submit"}]]]
+                :type "submit"}]
+       [:span.col-md-12
+        "There is multiple search query wildcards available, checkout the "
+        (link-to "" "guide")
+        "."]]]
      [:h2.getting-started.row
       [:span.col-md-12
        "To get started pushing your own project "

--- a/src/clojars/web/common.clj
+++ b/src/clojars/web/common.clj
@@ -214,7 +214,7 @@
                 :type "submit"}]
        [:span.col-md-12
         "There is multiple search query wildcards available, checkout the "
-        (link-to "" "guide")
+        (link-to "http://github.com/clojars/clojars-web/wiki/Search-Query-Syntax" "guide")
         "."]]]
      [:h2.getting-started.row
       [:span.col-md-12


### PR DESCRIPTION
Document Lucene syntax so people can be able to perform more effective advanced searches

I created [this wiki page](http://github.com/clojars/clojars-web/wiki/Search-Query-Syntax) and added a link to it below the search bar

Fix #125 
Related to #324 

![screen shot 2016-10-11 at 5 11 17 pm](https://cloud.githubusercontent.com/assets/1316543/19290543/c679cd90-8fd5-11e6-976a-4100cc6b81cb.png)
