### PR TITLE
Consolidate config using juxt/aero

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -52,7 +52,8 @@
                  [ring-jetty-component "0.3.1"]
                  [digest "1.4.4"]
                  [clj-http "3.3.0"
-                  :exclusions [commons-io]]]
+                  :exclusions [commons-io]]
+                 [aero "1.0.1"]]
   :plugins [[supersport "1"]]
   :main ^:skip-aot clojars.main
   :target-path "target/%s/"

--- a/resources/default_config.edn
+++ b/resources/default_config.edn
@@ -1,0 +1,23 @@
+{:port 8080
+ :bind "127.0.0.1"
+ :cdn-url "https://repo.clojars.org"
+ :db {:classname "org.sqlite.JDBC"
+      :subprotocol "sqlite"
+      :subname "data/db"}
+ :base-url "https://clojars.org"
+ :stats-dir "data/stats"
+ :queue-storage-dir "data/durable-queue-slabs"
+ :index-path "data/index"
+ :nrepl-port 7991
+ :mail {:hostname "127.0.0.1"
+        :ssl false
+        :from "noreply@clojars.org"}
+ :bcrypt-work-factor 12
+ :cloudfiles-user #env "CLOUDFILES_USER"
+ :deletion-backup-dir #env "DELETION_BACKUP_DIR"
+ :cloudfiles-token #env "CLOUDFILES_TOKEN"
+ :cdn-token #env "CDN_TOKEN"
+ :cloudfiles-container #env "CLOUDFILES_CONTAINER"
+ :yeller-environment "development"
+ :yeller-token #env "YELLER_TOKEN"
+ :repo #env "REPO"}

--- a/resources/default_config.edn
+++ b/resources/default_config.edn
@@ -13,11 +13,11 @@
         :ssl false
         :from "noreply@clojars.org"}
  :bcrypt-work-factor 12
- :cloudfiles-user #env "CLOUDFILES_USER"
- :deletion-backup-dir #env "DELETION_BACKUP_DIR"
- :cloudfiles-token #env "CLOUDFILES_TOKEN"
- :cdn-token #env "CDN_TOKEN"
- :cloudfiles-container #env "CLOUDFILES_CONTAINER"
+ :cloudfiles-user "NOTSET"
+ :deletion-backup-dir "NOTSET"
+ :cloudfiles-token "NOTSET"
+ :cdn-token "NOTSET"
+ :cloudfiles-container "NOTSET"
  :yeller-environment "development"
- :yeller-token #env "YELLER_TOKEN"
- :repo #env "REPO"}
+ :yeller-token "NOTSET"
+ :repo "NOTSET"}

--- a/src/clojars/config.clj
+++ b/src/clojars/config.clj
@@ -1,32 +1,8 @@
 (ns clojars.config
   (:require [clojure.tools.cli :refer [cli]]
             [clojure.java.io :as io]
+            [aero.core :as aero]
             [clojure.string :as str]))
-
-(def default-config
-  {:port 8080
-   :bind "127.0.0.1"
-   :cdn-url "https://repo.clojars.org"
-   :db {:classname "org.sqlite.JDBC"
-        :subprotocol "sqlite"
-        :subname "data/db"}
-   :base-url "https://clojars.org"
-   :stats-dir "data/stats"
-   :queue-storage-dir "data/durable-queue-slabs"
-   :index-path "data/index"
-   :nrepl-port 7991
-   :mail {:hostname "127.0.0.1"
-          :ssl false
-          :from "noreply@clojars.org"}
-   :bcrypt-work-factor 12
-   :yeller-environment "development"})
-
-(defn parse-resource [f]
-  (when-let [r (io/resource f)] (read-string (slurp r))))
-
-;; we attempt to read a config.clj from the classpath at load time
-;; this is handy for interactive development and unit tests
-(def config (merge default-config (parse-resource "config.clj")))
 
 (defn url-decode [s]
   (java.net.URLDecoder/decode s "UTF-8"))
@@ -53,64 +29,31 @@
 
 (defn parse-mail [x]
   (if (string? x)
-   (if (= (first x) \{)
-     (read-string x)
-     (parse-mail-uri x))
-   x))
+    (parse-mail-uri x)
+    x))
 
-(def env-vars
-  [["BIND" :bind]
-   ["CDN_TOKEN" :cdn-token]
-   ["CDN_URL" :cdn-url]
-   ["CLOUDFILES_CONTAINER" :cloudfiles-container]
-   ["CLOUDFILES_TOKEN" :cloudfiles-token]
-   ["CLOUDFILES_USER" :cloudfiles-user]
-   ["DATABASE_URL" :db]
-   ["DELETION_BACKUP_DIR" :deletion-backup-dir]
-   ["MAIL_URL" :mail parse-mail-uri]
-   ["NREPL_PORT" :nrepl-port #(Integer/parseInt %)]
-   ["PORT" :port #(Integer/parseInt %)]
-   ["REPO" :repo]
-   ["YELLER_ENV" :yeller-environment]
-   ["YELLER_TOKEN" :yeller-token]
-   ["CONFIG_FILE" :config-file]])
+(def default-config
+  (aero/read-config "resources/default_config.edn"))
 
-(defn parse-env []
-  (reduce
-   (fn [m [var k & [f]]]
-     (if-let [x (System/getenv var)]
-       (assoc m k ((or f identity) x))
-       m))
-   {} env-vars))
+;; we attempt to read a file defined on clojars.config.file property at load time
+;; this is handy for interactive development and unit tests
+(def config
+  (-> default-config
+      (merge (when-let [extra-config (System/getProperty "clojars.config.file")]
+               (aero/read-config extra-config)))
+      (update :mail parse-mail)))
 
-(defn parse-args [args defaults]
+(defn parse-args [args]
   (cli args
-       ["-h" "--help" "Show this help text and exit" :flag true]
-       ["-f" "Read configuration map from a file" :name :config-file]
-       ["-p" "--port" "Port to listen on for web requests"
-        :parse-fn #(Integer/parseInt %) :default (:port defaults)]
-       ["-b" "--bind" "Address to bind to for web requests"
-        :default (:address defaults)]
-       ["--db" "Database URL like sqlite:data/db"]
-       ["--mail" "SMTP URL like smtps://user:pass@host:port?from=me@example.org"]
-       ["--repo" "Path to store jar files in"]
-       ["--bcrypt-work-factor" "Difficulty factor for bcrypt password hashing"
-        :parse-fn #(Integer/parseInt %) :default (:bcrypt-work-factor defaults)]))
-
-(defn parse-file [f]
-  (read-string (slurp (io/file f))))
+       ["-h" "--help" "Show this help text and exit" :flag true]))
 
 (defn remove-nil-vals [m]
   (into {} (remove #(nil? (val %)) m)))
 
 (defn parse-config [args]
-  (let [env-opts (merge default-config (parse-resource "config.clj") (parse-env))
-        [arg-opts args banner] (parse-args args env-opts)
-        arg-opts (remove-nil-vals arg-opts)
-        opts (if-let [f (or (:config-file arg-opts) (:config-file env-opts))]
-               (merge env-opts (parse-file f) arg-opts)
-               (merge env-opts arg-opts))]
-    [opts args banner]))
+  (let [[arg-opts args banner] (parse-args args)
+        arg-opts (remove-nil-vals arg-opts)]
+    [arg-opts args banner]))
 
 (defn configure [args]
   (let [[options args banner] (parse-config args)]
@@ -121,8 +64,4 @@
       (println banner)
       (println "The config file must be a Clojure map: {:port 8080 :repo \"/var/repo\"}")
       (println "The :db and :mail options can be maps instead of URLs.")
-      (println)
-      (println "Some options can be set using these environment variables:")
-      (println (str/join " " (map first env-vars)))
-      (System/exit 0))
-    (alter-var-root #'config (fn [_] options))))
+      (System/exit 0))))

--- a/src/clojars/config.clj
+++ b/src/clojars/config.clj
@@ -33,7 +33,7 @@
     x))
 
 (def default-config
-  (aero/read-config "resources/default_config.edn"))
+  (aero/read-config (io/resource "resources/default_config.edn")))
 
 ;; we attempt to read a file defined on clojars.config.file property at load time
 ;; this is handy for interactive development and unit tests

--- a/test/clojars/test/unit/config.clj
+++ b/test/clojars/test/unit/config.clj
@@ -22,7 +22,5 @@
 (deftest parse-mail
   (is (= (config/parse-mail {:hostname "x"})
          {:hostname "x"}))
-  (is (= (config/parse-mail "{:hostname \"x\"}")
-         {:hostname "x"}))
   (is (= (config/parse-mail "smtp://x")
          {:hostname "x" :ssl false})))


### PR DESCRIPTION
This is a first version to try to fix #435 

I choose aero as a lib for config because it allows using env vars.

There are some env vars still being used on the default config file, I'm not sure if they should be removed from the default config or be replaced with hardcoded defaults. Let me know if you want some changes.