### PR TITLE
Wrap long JAR names in titles and recent jars

### DIFF
--- a/resources/public/stylesheets/screen.css
+++ b/resources/public/stylesheets/screen.css
@@ -364,7 +364,6 @@ footer a {
 
 .recent-jar-description {
   font-size: 1.1em;
-  margin-top: 35px;
 }
 
 .recent-jar-title {
@@ -375,18 +374,10 @@ footer a {
 .recent-jar-title a {
   color: #4098cf;
 
-  /* FIXME: this doesn't work well on long names and mobile */
-  white-space: nowrap;
+  overflow-wrap: break-word;
 
-  /* make the entire box clickable
-   *
-   * this is the only link in this box
-   */
   width: 100%;
   display: block;
-  padding: 20px 20px 110px;
-  margin: -20px 0 0 -20px;
-  position: absolute;
 }
 
 /* FIXME: should this be a class? */
@@ -457,6 +448,7 @@ footer a {
 
 #jar-title h1 a {
   color: #393536;
+  overflow-wrap: break-word;
 }
 
 #jar-title .description {


### PR DESCRIPTION
Fix for issue #475 

Project with a long name and no hyphens:
![wrapped_word](https://cloud.githubusercontent.com/assets/302132/19765513/1cdfeef6-9c49-11e6-82cd-43ce7ba3551d.png)

When possible, still wrap at a hyphen instead of truncating the word:
![hyphen_wrap](https://cloud.githubusercontent.com/assets/302132/19765512/1cdf9de8-9c49-11e6-9e03-e31d8f9bb147.png)

Recent projects in homepage:
![recent-wrapped](https://cloud.githubusercontent.com/assets/302132/19765514/1ce0ac60-9c49-11e6-81ee-1c7ee29f58c0.png)

Tested under responsive views in Firefox and Chrome.
