### PR TITLE
Don't allow deploys where group-id/artifact-id exists on central

### DIFF
--- a/src/clojars/maven.clj
+++ b/src/clojars/maven.clj
@@ -2,7 +2,8 @@
   (:require [clojure.java.io :as io]
             [clojars.config :refer [config]]
             [clojure.string :as str]
-            [clojars.errors :refer [report-error]])
+            [clojars.errors :refer [report-error]]
+            [clojars.file-utils :as fu])
   (:import org.apache.maven.model.io.xpp3.MavenXpp3Reader
            org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader
            java.io.IOException
@@ -200,4 +201,18 @@
       (compare (:incremental x 0) (:incremental y 0))
       (compare-qualifiers (:qualifier x) (:qualifier y))
       (compare (:build-number x 0) (:build-number y 0)))))
+
+(defn central-metadata
+  "Read the metadata from maven central for the given artifact."
+  [group name]
+  (try
+    (read-metadata
+      (format "https://repo1.maven.org/maven2/%s/%s/maven-metadata.xml" (fu/group->path group) name))
+    (catch java.io.FileNotFoundException _)))
+
+(def exists-on-central?
+  "Checks if any versions of the given artifact exist on central."
+  (comp boolean central-metadata))
+
+
 

--- a/test/clojars/test/integration/uploads.clj
+++ b/test/clojars/test/integration/uploads.clj
@@ -218,6 +218,23 @@
                                :password "password"}}
           :local-repo help/local-repo))))
 
+(deftest deploy-cannot-shadow-central
+  (-> (session (help/app-from-system))
+      (register-as "dantheman" "test@example.org" "password"))
+  (is (thrown-with-msg?
+        org.sonatype.aether.deployment.DeploymentException
+        #"Forbidden - shadowing Maven Central"
+        (aether/deploy
+          :coordinates '[org.tcrawley/dynapath "0.0.1"]
+          :jar-file (io/file (io/resource "test.jar"))
+          :pom-file (help/rewrite-pom (io/file (io/resource "test-0.0.1/test.pom"))
+                      {:groupId "org.tcrawley"
+                       :artifactId "dynapath"})
+          :repository {"test" {:url (repo-url)
+                               :username "dantheman"
+                               :password "password"}}
+          :local-repo help/local-repo))))
+
 (deftest user-can-redeploy-snapshots
   (-> (session (help/app-from-system))
       (register-as "dantheman" "test@example.org" "password"))


### PR DESCRIPTION
This prevents shadowing of libraries released to maven central. It
checks by seeing if it can access the maven-metadata.xml from central,
but doesn't allow a failure to contact central to fail the deploy, since
shadowing deploys are fairly rare.

This isn't quite ready, so don't merge - just parking here for discussion.

Related to #468 
