### PR TITLE
Fix #605 by clarifying profile page

### DIFF
--- a/src/clojars/web/user.clj
+++ b/src/clojars/web/user.clj
@@ -84,6 +84,7 @@
              (flash flash-msg)
              [:h1 "Profile"]
              (error-list errors)
+             [:p "Your Clojars profile is just your email address and your password. You can change them here, if want."]
              (form-to [:post "/profile"]
                       (label :email "Email")
                       [:input {:type :email :name :email :id


### PR DESCRIPTION
Adds a paragraph clarifying that your profile is just your email address and your password.