### PR TITLE
Escape some characters that are valid in descriptions but not in XML.

### DIFF
--- a/src/clojars/web/common.clj
+++ b/src/clojars/web/common.clj
@@ -340,3 +340,6 @@
      [:b (str (-> upper (- per-page) inc) " - " (min upper total))]
      " of "
      [:b total]]))
+
+(defn xml-escape [s]
+  (str/escape s {"'" "&apos;" "&" "&amp;" "<" "&lt;" ">" "&gt;"}))

--- a/src/clojars/web/error_api.clj
+++ b/src/clojars/web/error_api.clj
@@ -1,6 +1,8 @@
 (ns clojars.web.error-api
   (:require [ring.util.response :refer [response status content-type]]
+            [clojars.web.common :refer [xml-escape]]
             [cheshire.core :as json]
+            [clojure.string :as str]
             [clojure.xml :as xml]))
 
 (defn error-api-response [error-options error-id]
@@ -12,7 +14,7 @@
                  "Access-Control-Allow-Origin" "*"}
        :body (with-out-str
                (xml/emit {:tag :error
-                          :attrs {:message (:error-message options)
+                          :attrs {:message (xml-escape (:error-message options))
                                   :id error-id}}))}
       {:status (:status options)
        :headers {"Content-Type" "application/json; charset=UTF-8"

--- a/src/clojars/web/search.clj
+++ b/src/clojars/web/search.clj
@@ -1,7 +1,7 @@
 (ns clojars.web.search
   (:require [clojars.web.common :refer [html-doc jar-link jar-fork?
                                         collection-fork-notice user-link
-                                        format-date page-nav flash]]
+                                        format-date page-nav flash xml-escape]]
             [hiccup.element :refer [link-to]]
             [ring.util.codec :refer [url-encode]]
             [clojars.search :as search]
@@ -42,7 +42,7 @@
   (let [attrs {:jar_name (:artifact-id jar)
                :group_name (:group-id jar)
                :version (:version jar)
-               :description (:description jar)}
+               :description (xml-escape (:description jar))}
         created (:at jar)]
     {:tag :result :attrs (if created
                            (assoc attrs :created created)


### PR DESCRIPTION
Silly me; I thought that clojure.xml/emit would do this for me.

Fixes https://github.com/technomancy/leiningen/issues/2360