### PR TITLE
Switch CI to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+version: 2.0
+jobs:
+  build:
+    docker:
+      - image: clojure:lein-2.8.1
+    working_directory: ~/clojars
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - clojars-{{ checksum "project.clj" }}
+      - run: lein deps
+      - save_cache:
+          paths:
+            - $HOME/.m2
+            - $HOME/.lein
+          key: clojars-{{ checksum "project.clj" }}
+      - run: lein do run -m user/migrate, test, uberjar
+      - store_test_results:
+          path: target/test-results
+      - run: mv target/uberjar/clojars-web-*-standalone.jar clojars-uberjar.jar
+      - store_artifacts:
+          path: clojars-uberjar.jar
+          destination: uberjar

--- a/dev-resources/circleci_test/config.clj
+++ b/dev-resources/circleci_test/config.clj
@@ -1,0 +1,8 @@
+(require '[circleci.test.report :refer (clojure-test-reporter)])
+(require '[circleci.test.report.junit :as junit])
+
+{:selectors {:all (constantly true)
+             :default (complement :disabled)}
+ :test-results-dir (or (System/getenv "CIRCLE_TEST_REPORTS")
+                       "target/test-results")
+ :reporters [clojure-test-reporter junit/reporter]}

--- a/project.clj
+++ b/project.clj
@@ -68,7 +68,10 @@
                   ["change" "version" "super.sport/bump-version"]
                   ["vcs" "commit"]
                   ["vcs" "push"]]
-  :aliases {"migrate" ["run" "-m" "clojars.tools.migrate-db"]}
+  :aliases {"migrate" ["run" "-m" "clojars.tools.migrate-db"]
+            "test" ["run" "-m" "circleci.test/dir" :project/test-paths]
+            "tests" ["run" "-m" "circleci.test"]
+            "retest" ["run" "-m" "circleci.test.retest"]}
   :pedantic? :abort
   :profiles
   {:dev  [:project/dev  :profiles/dev]
@@ -82,6 +85,7 @@
                    :dependencies [[reloaded.repl "0.2.0"]
                                   [org.clojure/tools.namespace "0.2.11"]
                                   [eftest "0.1.0"]
+                                  [circleci/circleci.test "0.3.1"]
                                   [kerodon "0.7.0"
                                    :exclusions [org.apache.httpcomponents/httpcore
                                                 ring/ring-codec]]

--- a/src/clojars/tools/repair_metadata.clj
+++ b/src/clojars/tools/repair_metadata.clj
@@ -63,7 +63,7 @@
 
 (defn repair-versions [{:keys [file metadata version-dirs]}]
   (let [versioning (get-versioning metadata)
-        sorted-dirs (sort-by #(.lastModified %) version-dirs)]
+        sorted-dirs (sort-by (juxt (memfn lastModified) str) version-dirs)]
     ;; remove existing versions, then write dir versions in dir creation order
     (run! #(.removeVersion versioning %) (into [] (.getVersions versioning)))
     (run! #(.addVersion versioning %) (map (memfn getName) sorted-dirs))

--- a/test/clojars/test/unit/tools/repair_metadata.clj
+++ b/test/clojars/test/unit/tools/repair_metadata.clj
@@ -53,7 +53,7 @@
         (let [md (mvn/read-metadata bar-file)
               versioning (.getVersioning md)]
           (is (= "0.4.0" (.getRelease versioning)))
-          (is (= versions (.getVersions versioning)))))
+          (is (= (set versions) (set (.getVersions versioning))))))
 
       (testing "writes correct sums"
         (is (futil/valid-checksum-file? bar-file :md5))

--- a/test/clojars/test/unit/tools/repair_metadata.clj
+++ b/test/clojars/test/unit/tools/repair_metadata.clj
@@ -53,7 +53,7 @@
         (let [md (mvn/read-metadata bar-file)
               versioning (.getVersioning md)]
           (is (= "0.4.0" (.getRelease versioning)))
-          (is (= (set versions) (set (.getVersions versioning))))))
+          (is (= versions (.getVersions versioning)))))
 
       (testing "writes correct sums"
         (is (futil/valid-checksum-file? bar-file :md5))


### PR DESCRIPTION
You mentioned on IRC you might be interested in this.

The tests won't actually pass, because they're currently broken for other reasons, but this will be more repeatable since it's tied to a specific docker image and won't randomly have things like the `lein2` script disappear out from under it.

I switched to using the `circleci.test` library so that we can get nice test result reporting along with stdout test reporting (`clojure.test` supports them both, but not at the same time), but if you'd rather have this change only applied during CI instead of every time you run `lein test` I can do that too.