### PR TITLE
Allow human-readable datetime format for searching clojars.

### DIFF
--- a/src/clojars/search.clj
+++ b/src/clojars/search.clj
@@ -159,31 +159,31 @@
            (catch Exception e query)))))
 
 ; http://stackoverflow.com/questions/963781/how-to-achieve-pagination-in-lucene
-  (defn -search [stats index query page]
-    (if (empty? query)
-      []
-      (binding [clucy/*analyzer* analyzer]
-        (with-open [searcher (IndexSearcher. index)]
-          (let [per-page 24
-                offset (* per-page (- page 1))
-                parser (QueryParser. clucy/*version*
-                                     "_content"
-                                     clucy/*analyzer*)
-                query  (.parse parser (replace-time-range query))
-                query  (CustomScoreQuery. query (download-values stats))
-                hits   (.search searcher query (* per-page page))
-                highlighter (#'clucy/make-highlighter query searcher nil)]
-            (doall
-             (let [dhits (take per-page (drop offset (.scoreDocs hits)))]
-               (with-meta (for [hit dhits]
-                            (#'clucy/document->map
-                             (.doc searcher (.doc hit))
-                             (.score hit)
-                             highlighter))
-                 {:total-hits (.totalHits hits)
-                  :max-score (.getMaxScore hits)
-                  :results-per-page per-page
-                  :offset offset}))))))))
+(defn -search [stats index query page]
+  (if (empty? query)
+    []
+    (binding [clucy/*analyzer* analyzer]
+      (with-open [searcher (IndexSearcher. index)]
+        (let [per-page 24
+              offset (* per-page (- page 1))
+              parser (QueryParser. clucy/*version*
+                                   "_content"
+                                   clucy/*analyzer*)
+              query  (.parse parser (replace-time-range query))
+              query  (CustomScoreQuery. query (download-values stats))
+              hits   (.search searcher query (* per-page page))
+              highlighter (#'clucy/make-highlighter query searcher nil)]
+          (doall
+           (let [dhits (take per-page (drop offset (.scoreDocs hits)))]
+             (with-meta (for [hit dhits]
+                          (#'clucy/document->map
+                           (.doc searcher (.doc hit))
+                           (.score hit)
+                           highlighter))
+               {:total-hits (.totalHits hits)
+                :max-score (.getMaxScore hits)
+                :results-per-page per-page
+                :offset offset}))))))))
 
 (defrecord LuceneSearch [stats index-factory index]
   Search


### PR DESCRIPTION
- Fixes #602 
- Currently, one can search clojars with the syntax: `at:[<start> TO<end>]`, where start and end are in milliseconds since epoch. This is simply lucene query syntax to match agaisnt the `at` field. This format will continue to be supported.
- Allowed human-readable ISO-8601 datetime format instead of epoch millis, such as `at:[2017-01-01T00:00:00Z TO 2018-01-01T00:00:00Z]`. We regex-match for a time search in the query and replace it with the corresponding epoch millis. 