### PR TITLE
Add Clojure CLI coordinates for easy deps.edn copy-and-paste

### DIFF
--- a/src/clojars/web/jar.clj
+++ b/src/clojars/web/jar.clj
@@ -127,6 +127,17 @@
           [:span.string " \""
            (:version jar) "\""] (tag "]")]]
 
+        [:h2 "Clojure CLI"]
+        [:div#deps-coordinates.package-config-example
+         {:onClick "selectText('deps-coordinates');"}
+         [:pre
+          (jar-name jar)
+          \space
+          (tag "{")
+          ":mvn/version "
+          [:span.string \" (:version jar) \"]
+          (tag "}")]]
+
         [:h2 "Gradle"]
         [:div#gradle-coordinates.package-config-example
          {:onClick "selectText('gradle-coordinates');"}


### PR DESCRIPTION
There is a new de iure (ie, Cognitect-supplied) standard for Clojure
dependencies, that is the new Clojure 1.9 CLI tools format as used in
`deps.edn` files.

I think we should include this for copy-and-paste convenience.

I have added the new coordinates at the top – the whole page seems to
fit on the screen easily enough without scrolling, so the de facto
standard Leiningen/Boot can still be spotted at once.
