### PR TITLE
Use single quotes in Gradle coordinates

### DIFF
--- a/src/clojars/web/jar.clj
+++ b/src/clojars/web/jar.clj
@@ -133,13 +133,13 @@
          [:pre
           "compile "
           [:span.string
-           \"
+           \'
            (:group_name jar)
            ":"
            (:jar_name jar)
            ":"
            (:version jar)
-           \"]]]
+           \']]]
 
         [:h2 "Maven"]
         [:div#maven-coordinates.package-config-example


### PR DESCRIPTION
The idiomatic, or most common way of using quotes in Gradle dependencies
seems to be the single quote – see the official Gradle documentation (or
how Maven central does it). Single quotes are simply strings, no
templating magic involved.

I expect that using single quotes instead of double quotes on the JAR
page will allow most users to forgo any additional editing step on
copied-and-pasted coordinates.

Thank you!
