### PR TITLE
Use chars when calling clojure.string/escape for XML search results.

### DIFF
--- a/src/clojars/web/common.clj
+++ b/src/clojars/web/common.clj
@@ -342,4 +342,4 @@
      [:b total]]))
 
 (defn xml-escape [s]
-  (str/escape s {"'" "&apos;" "&" "&amp;" "<" "&lt;" ">" "&gt;"}))
+  (str/escape s {\' "&apos;" \& "&amp;" \< "&lt;" \> "&gt;"}))


### PR DESCRIPTION
Fixes https://github.com/technomancy/leiningen/issues/2360 for real; oops.