### PR TITLE
Remove Google Analytics

### DIFF
--- a/src/clojars/web/common.clj
+++ b/src/clojars/web/common.clj
@@ -78,15 +78,6 @@
      ]
     [:footer.row]))
 
-(defn google-analytics-js []
-  [:script (raw "(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-51806851-1', 'clojars.org');
-  ga('send', 'pageview');")])
-
 (defn typekit-js []
   [:script "try{Typekit.load({async:true});}catch(e){}"])
 
@@ -115,7 +106,6 @@
          ["reset.css" "vendor/bootstrap/bootstrap.css" "screen.css"])
     (include-js "https://use.typekit.net/zhw0tse.js")
     (typekit-js)
-    (google-analytics-js)
     (raw (when-ie (include-js "/js/html5.js")))]
    [:body.container-fluid
     [:div#content-wrapper
@@ -187,7 +177,6 @@
          ["reset.css" "vendor/bootstrap/bootstrap.css" "screen.css"])
     (include-js "https://use.typekit.net/zhw0tse.js")
     (typekit-js)
-    (google-analytics-js)
     (raw (when-ie (include-js "/js/html5.js")))]
    [:body.container-fluid
     [:div.hero.row


### PR DESCRIPTION
We don't use this information for anything, and it has GDPR
complications around allowing opting-out, so we'll just stop collecting
it.