### PR TITLE
Add login with GitHub

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -32,6 +32,7 @@
                                org.clojure/core.cache
                                ring/ring-core
                                slingshot]]
+                 [com.github.scribejava/scribejava-apis "7.1.1"]
                  [buddy/buddy-core "1.6.0"
                   :exclusions [commons-codec]]
                  [clj-stacktrace "0.2.8"]

--- a/resources/default_config.edn
+++ b/resources/default_config.edn
@@ -34,4 +34,6 @@
       :stats-bucket #profile {:default "clojars-stats-development"
                               :production "clojars-stats-production"}}
  :sentry-dsn "NOTSET"
- :stats-dir "data/stats"}
+ :stats-dir "data/stats"
+ :github-api-key "NOTSET"
+ :github-api-secret "NOTSET"}

--- a/resources/public/stylesheets/screen.css
+++ b/resources/public/stylesheets/screen.css
@@ -664,9 +664,13 @@ a.github-button {
   -webkit-appearence: button;
   text-align: center;
 
-  margin-top: 25px;
+  margin-top: 15px;
 }
 
 a.github-button:hover, a.github-button:focus {
   text-decoration: none;
+}
+
+#login-or {
+  text-align: center;
 }

--- a/resources/public/stylesheets/screen.css
+++ b/resources/public/stylesheets/screen.css
@@ -110,7 +110,7 @@ hr {
 }
 
 /* FIXME: add active/hover states? */
-input[type=submit] {
+input[type=submit], a.github-button {
   font-size: 1.2em;
   letter-spacing: 1px;
   font-weight: 300;
@@ -654,4 +654,19 @@ table.deploy-tokens td.token-disabled {
 .new-token pre {
     background-color: #e9e9e9;
     padding: 5px;
+}
+
+a.github-button {
+  background: #24292e;
+  color: #ffffff;
+  padding: 5px 10px;
+  display: block;
+  -webkit-appearence: button;
+  text-align: center;
+
+  margin-top: 25px;
+}
+
+a.github-button:hover, a.github-button:focus {
+  text-decoration: none;
 }

--- a/resources/queries/queryfile.sql
+++ b/resources/queries/queryfile.sql
@@ -20,6 +20,14 @@ WHERE (
 )
 LIMIT 1;
 
+--name: find-user-by-email-in
+SELECT *
+FROM users
+WHERE (
+  email IN (:email)
+)
+LIMIT 1;
+
 --name: find-user-by-password-reset-code
 SELECT *
 FROM users

--- a/src/clojars/db.clj
+++ b/src/clojars/db.clj
@@ -96,6 +96,11 @@
                                   {:connection db
                                    :result-set-fn first}))
 
+(defn find-user-by-email-in [db emails]
+  (sql/find-user-by-email-in {:email emails}
+                             {:connection db
+                              :result-set-fn first}))
+
 (defn find-user-by-password-reset-code [db reset-code]
   (sql/find-user-by-password-reset-code {:reset_code reset-code
                                          :reset_code_created_at

--- a/src/clojars/friend/github.clj
+++ b/src/clojars/friend/github.clj
@@ -1,0 +1,31 @@
+(ns clojars.friend.github
+  (:require [ring.util.response :refer [redirect]]
+            [cemerick.friend.workflows :as workflow]
+            [clojars.github :as github]
+            [clojars.db :as db]))
+
+(defn authorize [req service]
+  (redirect (github/authorization-url service)))
+
+(defn callback [req service db]
+  (let [code (-> req :params :code)
+        token (github/access-token service code)
+        email (github/get-primary-email service token)]
+    (if (not (:verified email))
+      (assoc (redirect "/login")
+             :flash "Your primary e-mail is not verified")
+
+      (if-let [user (db/find-user-by-user-or-email db (:email email))]
+
+        (let [username (:user user)]
+          (workflow/make-auth {:identity username :username username}))
+
+        (assoc (redirect "/register")
+               :flash "Your primary e-mail is not registered")))))
+
+(defn workflow [service db]
+  (fn [req]
+    (case (:uri req)
+      "/oauth/github/authorize" (authorize req service)
+      "/oauth/github/callback" (callback req service db)
+      nil)))

--- a/src/clojars/friend/github.clj
+++ b/src/clojars/friend/github.clj
@@ -7,27 +7,49 @@
 (defn authorize [req service]
   (redirect (github/authorization-url service)))
 
-(defn callback [req service db]
-  (if-let [error (-> req :params :error)]
-    (if (= error "access_denied")
-      (assoc (redirect "/login")
-             :flash "You declined access to your account")
-      (throw (Exception. (str (-> req :params :error_description)))))
-
-    (let [code (-> req :params :code)
-          token (github/access-token service code)
-          emails (github/get-verified-emails service token)]
-      (if (empty? emails)
+(defn- handle-error [{:keys [params]}]
+  (let [{:keys [error error_description]} params]
+    (when error
+      (if (= error "access_denied")
         (assoc (redirect "/login")
-               :flash "No verified e-mail was found")
+               :flash "You declined access to your account")
+        (throw (ex-info error_description {:error error}))))))
 
-        (if-let [user (db/find-user-by-email-in db emails)]
+(defn- get-emails [{:keys [params] ::keys [service]}]
+  (let [code (:code params)
+        token (github/access-token service code)
+        emails (github/get-verified-emails service token)]
+    (if (seq emails)
+      {::emails emails}
+      (assoc (redirect "/login")
+             :flash "No verified e-mail was found"))))
 
-          (let [username (:user user)]
-            (workflow/make-auth {:identity username :username username}))
+(defn- find-user [{::keys [db emails]}]
+  (if-let [user (db/find-user-by-email-in db emails)]
+    {::user user}
+    (assoc (redirect "/register")
+           :flash "None of your e-mails are registered")))
 
-          (assoc (redirect "/register")
-                 :flash "None of your e-mails are registered"))))))
+(defn- make-auth [{::keys [user]}]
+  (let [username (:user user)]
+    {:identity username :username username}))
+
+(defn callback [req service db]
+  (reduce (fn [acc f]
+            (let [res (merge acc (f acc))]
+              (cond
+                (:status res)   (reduced res)
+                (:identity res) (workflow/make-auth res)
+                :else           res)))
+
+          (assoc req
+                 ::db db
+                 ::service service)
+
+          [handle-error
+           get-emails
+           find-user
+           make-auth]))
 
 (defn workflow [service db]
   (fn [req]

--- a/src/clojars/friend/github.clj
+++ b/src/clojars/friend/github.clj
@@ -10,18 +10,18 @@
 (defn callback [req service db]
   (let [code (-> req :params :code)
         token (github/access-token service code)
-        email (github/get-primary-email service token)]
-    (if (not (:verified email))
+        emails (github/get-verified-emails service token)]
+    (if (empty? emails)
       (assoc (redirect "/login")
-             :flash "Your primary e-mail is not verified")
+             :flash "No verified e-mail was found")
 
-      (if-let [user (db/find-user-by-user-or-email db (:email email))]
+      (if-let [user (db/find-user-by-email-in db emails)]
 
         (let [username (:user user)]
           (workflow/make-auth {:identity username :username username}))
 
         (assoc (redirect "/register")
-               :flash "Your primary e-mail is not registered")))))
+               :flash "None of your e-mails are registered")))))
 
 (defn workflow [service db]
   (fn [req]

--- a/src/clojars/friend/registration.clj
+++ b/src/clojars/friend/registration.clj
@@ -21,7 +21,8 @@
           (->
            (response (register-form {:errors (apply concat (vals errors))
                                      :email email
-                                     :username username}))
+                                     :username username}
+                                    nil))
            (content-type "text/html")))
         (do
           (add-user db email username password)

--- a/src/clojars/github.clj
+++ b/src/clojars/github.clj
@@ -47,5 +47,5 @@
     (mapv :email (filter :verified (:email config)))))
 
 (defn new-mock-github-service [config]
-  (map->MockGitHubService {:config (merge {:authorize-uri "http://github.com/oauth/authorize"}
+  (map->MockGitHubService {:config (merge {:authorize-uri "https://github.com/login/oauth/authorize"}
                                           config)}))

--- a/src/clojars/github.clj
+++ b/src/clojars/github.clj
@@ -8,7 +8,7 @@
 (defprotocol SocialService
   (authorization-url [service])
   (access-token [service code])
-  (get-primary-email [service token]))
+  (get-verified-emails [service token]))
 
 (defrecord GitHubService [service]
   SocialService
@@ -19,11 +19,11 @@
   (access-token [this code]
     (.getAccessToken (.getAccessToken service code)))
 
-  (get-primary-email [this token]
+  (get-verified-emails [this token]
     (let [emails (-> (http/get "https://api.github.com/user/emails" {:oauth-token token})
                      :body
                      (json/parse-string true))]
-      (->> emails (filter :primary) first))))
+      (->> emails (filter :verified) (mapv :email)))))
 
 (defn- build-github-service [api-key api-secret callback-uri]
   (-> (ServiceBuilder. api-key)
@@ -43,8 +43,8 @@
   (access-token [this code]
     (:access-token config))
 
-  (get-primary-email [this token]
-    (:email config)))
+  (get-verified-emails [this token]
+    (mapv :email (filter :verified (:email config)))))
 
 (defn new-mock-github-service [config]
   (map->MockGitHubService {:config (merge {:authorize-uri "http://github.com/oauth/authorize"}

--- a/src/clojars/github.clj
+++ b/src/clojars/github.clj
@@ -14,7 +14,7 @@
   SocialService
 
   (authorization-url [this]
-    (.getAuthorizationUrl service))
+    (.getAuthorizationUrl service {"scope" "user:email"}))
 
   (access-token [this code]
     (.getAccessToken (.getAccessToken service code)))

--- a/src/clojars/github.clj
+++ b/src/clojars/github.clj
@@ -1,0 +1,51 @@
+(ns clojars.github
+  (:require [clj-http.client :as http]
+            [cheshire.core :as json])
+
+  (:import [com.github.scribejava.core.builder ServiceBuilder]
+           [com.github.scribejava.apis GitHubApi]))
+
+(defprotocol SocialService
+  (authorization-url [service])
+  (access-token [service code])
+  (get-primary-email [service token]))
+
+(defrecord GitHubService [service]
+  SocialService
+
+  (authorization-url [this]
+    (.getAuthorizationUrl service))
+
+  (access-token [this code]
+    (.getAccessToken (.getAccessToken service code)))
+
+  (get-primary-email [this token]
+    (let [emails (-> (http/get "https://api.github.com/user/emails" {:oauth-token token})
+                     :body
+                     (json/parse-string true))]
+      (->> emails (filter :primary) first))))
+
+(defn- build-github-service [api-key api-secret callback-uri]
+  (-> (ServiceBuilder. api-key)
+      (.apiSecret api-secret)
+      (.callback callback-uri)
+      (.build (GitHubApi/instance))))
+
+(defn new-github-service [api-key api-secret callback-uri]
+  (map->GitHubService {:service (build-github-service api-key api-secret callback-uri)}))
+
+(defrecord MockGitHubService [config]
+  SocialService
+
+  (authorization-url [this]
+    (:authorize-uri config))
+
+  (access-token [this code]
+    (:access-token config))
+
+  (get-primary-email [this token]
+    (:email config)))
+
+(defn new-mock-github-service [config]
+  (map->MockGitHubService {:config (merge {:authorize-uri "http://github.com/oauth/authorize"}
+                                          config)}))

--- a/src/clojars/routes/session.clj
+++ b/src/clojars/routes/session.clj
@@ -5,7 +5,8 @@
             [clojars.web.login :as view]))
 
 (defroutes routes
-  (GET "/login" [login_failed username]
-       (view/login-form login_failed username))
+  (GET "/login" {:keys [flash params]}
+       (let [{:keys [login_failed username]} params]
+         (view/login-form login_failed username flash)))
   (friend/logout
    (ANY "/logout" _ (response/redirect "/"))))

--- a/src/clojars/routes/user.clj
+++ b/src/clojars/routes/user.clj
@@ -120,8 +120,8 @@
          (auth/with-account
            #(disable-mfa db % (db/find-user db %) params)))
 
-   (GET "/register" {:keys [params]}
-        (view/register-form params))
+   (GET "/register" {:keys [params flash]}
+        (view/register-form params flash))
 
    (GET "/forgot-password" _
         (view/forgot-password-form))

--- a/src/clojars/system.clj
+++ b/src/clojars/system.clj
@@ -11,6 +11,7 @@
    [clojars.stats :refer [artifact-stats]]
    [clojars.storage :as storage]
    [clojars.web :as web]
+   [clojars.github :as github]
    [clucy.core :as clucy]
    [com.stuartsierra.component :as component]
    [duct.component.endpoint :refer [endpoint-component]]
@@ -69,6 +70,9 @@
          :mailer            (simple-mailer (:mail config))
          :notifications     (notifications/notification-component)
          :storage           (storage-component (:repo config) (:cdn-token config) (:cdn-url config))
+         :github            (github/new-github-service (:github-api-key config)
+                                                       (:github-api-secret config)
+                                                       (:github-callback-uri config))
          :clojars-app       (endpoint-component web/handler-optioned))
         (component/system-using
          {:http              [:app]
@@ -77,4 +81,4 @@
           :stats             [:stats-bucket]
           :search            [:index-factory :stats]
           :storage           [:repo-bucket]
-          :clojars-app       [:storage :db :error-reporter :stats :search :mailer]}))))
+          :clojars-app       [:storage :db :error-reporter :stats :search :mailer :github]}))))

--- a/src/clojars/web.clj
+++ b/src/clojars/web.clj
@@ -10,6 +10,7 @@
     [http-utils :refer [wrap-x-frame-options wrap-secure-session]]
     [middleware :refer [wrap-ignore-trailing-slash]]]
    [clojars.friend.registration :as registration]
+   [clojars.friend.github :as github]
    [clojars.log :as log]
    [clojars.routes.api :as api]
    [clojars.routes.artifact :as artifact]
@@ -97,7 +98,7 @@
                [:h1 "Page not found"]
                [:p "Thundering typhoons!  I think we lost it.  Sorry!"]]))))))
 
-(defn clojars-app [storage db reporter stats search mailer]
+(defn clojars-app [storage db reporter stats search mailer github]
   (routes
     (-> (context "/repo" _
           (-> (repo/routes storage db search)
@@ -120,7 +121,8 @@
        (friend/authenticate
         {:credential-fn (auth/password-credential-fn db)
          :workflows [(auth/interactive-form-with-mfa-workflow)
-                     (registration/workflow db)]})
+                     (registration/workflow db)
+                     (github/workflow github db)]})
        (wrap-exceptions reporter)
        (log/wrap-request-context)
        (wrap-anti-forgery)
@@ -135,5 +137,5 @@
        (wrap-not-modified)
        (wrap-ignore-trailing-slash))))
 
-(defn handler-optioned [{:keys [storage db error-reporter stats search mailer]}]
-  (clojars-app storage (:spec db) error-reporter stats search mailer))
+(defn handler-optioned [{:keys [storage db error-reporter stats search mailer github]}]
+  (clojars-app storage (:spec db) error-reporter stats search mailer github))

--- a/src/clojars/web/login.clj
+++ b/src/clojars/web/login.clj
@@ -1,18 +1,20 @@
 (ns clojars.web.login
   (:require
-   [clojars.web.common :refer [html-doc]]
+   [clojars.web.common :refer [html-doc flash]]
    [clojars.web.safe-hiccup :refer [form-to]]
    [clojure.string :as str]
    [hiccup.element :refer [link-to]]
    [hiccup.form :refer [label text-field
                         password-field submit-button]]))
 
-(defn login-form [login_failed username]
+(defn login-form [login_failed username message]
   (html-doc "Login" {}
    [:div.small-section
     [:h1 "Login"]
     [:p.hint "Don't have an account? "
      (link-to "/register" "Sign up!")]
+
+    (flash message)
 
     (when login_failed
       [:div
@@ -37,4 +39,5 @@
              (text-field {:placeholder "leave blank if two-factor auth not enabled"}
                          :otp)
              (link-to {:class :hint-link} "/forgot-password" "Forgot your username or password?")
+             (link-to {:class :github-button} "/oauth/github/authorize" "Login with GitHub")
              (submit-button "Login"))]))

--- a/src/clojars/web/login.clj
+++ b/src/clojars/web/login.clj
@@ -39,5 +39,7 @@
              (text-field {:placeholder "leave blank if two-factor auth not enabled"}
                          :otp)
              (link-to {:class :hint-link} "/forgot-password" "Forgot your username or password?")
-             (link-to {:class :github-button} "/oauth/github/authorize" "Login with GitHub")
-             (submit-button "Login"))]))
+
+             (submit-button "Login")
+             [:div#login-or "or"]
+             (link-to {:class :github-button} "/oauth/github/authorize" "Login with GitHub"))]))

--- a/src/clojars/web/user.clj
+++ b/src/clojars/web/user.clj
@@ -21,10 +21,11 @@
    [valip.predicates :as pred]
    [clojars.log :as log]))
 
-(defn register-form [{:keys [errors email username]}]
+(defn register-form [{:keys [errors email username]} message]
   (html-doc "Register" {}
             [:div.small-section
              [:h1 "Register"]
+             (flash message)
              (error-list errors)
              (form-to [:post "/register"]
                       (label :email "Email")

--- a/test/clojars/test_helper.clj
+++ b/test/clojars/test_helper.clj
@@ -4,6 +4,7 @@
    [clojars.db.migrate :as migrate]
    [clojars.email :as email]
    [clojars.errors :as errors]
+   [clojars.github :as github]
    [clojars.s3 :as s3]
    [clojars.search :as search]
    [clojars.stats :as stats]
@@ -99,14 +100,14 @@
 
 (defn app
   ([] (app {}))
-  ([{:keys [storage db error-reporter stats search mailer]
+  ([{:keys [storage db error-reporter stats search mailer github]
      :or {db *db*
           storage (storage/fs-storage (:repo (config/config)))
           error-reporter (quiet-reporter)
           stats (no-stats)
           search (no-search)
           mailer nil}}]
-   (web/clojars-app storage db error-reporter stats search mailer)))
+   (web/clojars-app storage db error-reporter stats search mailer github)))
 
 (declare ^:dynamic system)
 
@@ -125,7 +126,8 @@
                                              :error-reporter (quiet-reporter)
                                              :index-factory #(clucy/memory-index)
                                              :mailer (email/mock-mailer)
-                                             :stats (no-stats)))]
+                                             :stats (no-stats)
+                                             :github (github/new-mock-github-service {})))]
       (let [db (get-in system [:db :spec])]
         (try
           (clear-database db)

--- a/test/clojars/unit/friend/github_test.clj
+++ b/test/clojars/unit/friend/github_test.clj
@@ -19,7 +19,8 @@
     (let [req {:uri "/oauth/github/authorize"}
           response (handle-with-config req {})]
 
-      (is (some? (-> response :headers (get "Location")))))))
+      (is (some? (re-matches #"https://github.com/login/oauth/authorize.*"
+                             (-> response :headers (get "Location"))))))))
 
 (deftest test-callback
   (testing "with a valid user"

--- a/test/clojars/unit/friend/github_test.clj
+++ b/test/clojars/unit/friend/github_test.clj
@@ -73,4 +73,17 @@
           response (handle-with-config req config)]
 
       (is (= (-> response :headers (get "Location")) "/login"))
-      (is (= (:flash response) "No verified e-mail was found")))))
+      (is (= (:flash response) "No verified e-mail was found"))))
+
+  (testing "with an error returned to the callback"
+    (let [req {:uri "/oauth/github/callback"
+               :params {:error "access_denied"
+                        :error_description "The user has denied your application access."
+                        :error_uri "https://docs.github.com/apps/managing-oauth-apps/troubleshooting-authorization-request-errors/#access-denied"}}
+          config {:email [{:email "john.doe@example.org"
+                           :primary true
+                           :verified true}]}
+
+          response (handle-with-config req config)]
+      (is (= (-> response :headers (get "Location")) "/login"))
+      (is (= (:flash response) "You declined access to your account")))))

--- a/test/clojars/unit/friend/github_test.clj
+++ b/test/clojars/unit/friend/github_test.clj
@@ -32,9 +32,11 @@
                            :primary true
                            :verified true}]}
 
-          response (handle-with-config req config)]
+          response (handle-with-config req config)
 
-      (is (= response {:identity "johndoe" :username "johndoe"}))))
+          {:keys [identity username]} response]
+
+      (is (and (= identity "johndoe") (= username "johndoe")))))
 
   (testing "with a valid user which the clojars email is not the primary one"
     (db/add-user help/*db* "jane.dot@example.org" "janedot" "pwd12345")
@@ -48,9 +50,11 @@
                            :primary false
                            :verified true}]}
 
-          response (handle-with-config req config)]
+          response (handle-with-config req config)
 
-      (is (= response {:identity "janedot" :username "janedot"}))))
+          {:keys [identity username]} response]
+
+      (is (and (= identity "janedot") (= username "janedot")))))
 
   (testing "with a non existing e-mail"
     (let [req {:uri "/oauth/github/callback"

--- a/test/clojars/unit/friend/github_test.clj
+++ b/test/clojars/unit/friend/github_test.clj
@@ -1,0 +1,60 @@
+(ns clojars.unit.friend.github-test
+  (:require [clojure.test :refer [deftest testing is join-fixtures use-fixtures]]
+            [clojars.friend.github :refer [workflow]]
+            [clojars.github :as github]
+            [clojars.db :as db]
+
+            [clojars.test-helper :as help]))
+
+(use-fixtures :each
+  (join-fixtures
+    [help/default-fixture
+     help/with-clean-database]))
+
+(defn handle-with-config [req config]
+  ((workflow (github/new-mock-github-service config) help/*db*) req))
+
+(deftest test-authorization
+  (testing "accessing the authorization url"
+    (let [req {:uri "/oauth/github/authorize"}
+          response (handle-with-config req {})]
+
+      (is (some? (-> response :headers (get "Location")))))))
+
+(deftest test-callback
+  (testing "with a valid user"
+    (db/add-user help/*db* "john.doe@example.org" "johndoe" "pwd12345")
+
+    (let [req {:uri "/oauth/github/callback"
+               :params {:code "1234567890"}}
+          config {:email {:email "john.doe@example.org"
+                          :primary true
+                          :verified true}}
+
+          response (handle-with-config req config)]
+
+      (is (= response {:identity "johndoe" :username "johndoe"}))))
+
+  (testing "with a non existing e-mail"
+    (let [req {:uri "/oauth/github/callback"
+               :params {:code "1234567890"}}
+          config {:email {:email "foolano@example.org"
+                          :primary true
+                          :verified true}}
+
+          response (handle-with-config req config)]
+
+      (is (= (-> response :headers (get "Location")) "/register"))
+      (is (= (:flash response) "Your primary e-mail is not registered"))))
+
+  (testing "with a non verified e-mail"
+    (let [req {:uri "/oauth/github/callback"
+               :params {:code "1234567890"}}
+          config {:email {:email "foolano@example.org"
+                          :primary true
+                          :verified false}}
+
+          response (handle-with-config req config)]
+
+      (is (= (-> response :headers (get "Location")) "/login"))
+      (is (= (:flash response) "Your primary e-mail is not verified")))))


### PR DESCRIPTION
Implements login with GitHub. I just introduced another authentication workflow for `com.cemerick/friend`, which just validates the presence of the e-mail on the database and authenticates the user. Used `com.github.scribejava/scribejava-apis` as OAuth2 implementation. Build an abstraction `SocialService`, which can be used in the future as basis for implementation of other social logins. 

Needs to add `:github-api-key`, `:github-api-secret` and optionally `:github-callback-uri` (it has to be configured on GitHub anyway).

Implements #728.