### PR TITLE
Display group name for deps.edn

### DIFF
--- a/src/clojars/web/jar.clj
+++ b/src/clojars/web/jar.clj
@@ -116,17 +116,17 @@
       [:span.string " \""
        (:version jar) "\""] (tag "]")]]))
 
-(defn clojure-cli-coordinates [jar]
+(defn clojure-cli-coordinates [{:keys [group_name jar_name version]}]
   (list
     [:h2 "Clojure CLI/deps.edn"]
     [:div#deps-coordinates.package-config-example
      {:onClick "selectText('deps-coordinates');"}
      [:pre
-      (jar-name jar)
+      (str group_name "/" jar_name)
       \space
       (tag "{")
       ":mvn/version "
-      [:span.string \" (:version jar) \"]
+      [:span.string \" version \"]
       (tag "}")]]))
 
 (defn gradle-coordinates [{:keys [group_name jar_name version]}]


### PR DESCRIPTION
deps.edn no longer supports the short style, and requires that the group
name always be provided.

I haven't actually run this, I'm relying on the simplicity for it to be
correct.  Installing and configuring docker for just this seemed a
little overkill I'm afraid.