### PR TITLE
Add GitHub logo to "Login with GitHub" button

### DIFF
--- a/resources/public/stylesheets/screen.css
+++ b/resources/public/stylesheets/screen.css
@@ -667,6 +667,11 @@ a.github-button {
   margin-top: 15px;
 }
 
+a.github-button img {
+  filter: invert(100%);
+  margin: 0 10px 5px 0;
+}
+
 a.github-button:hover, a.github-button:focus {
   text-decoration: none;
 }

--- a/src/clojars/web/login.clj
+++ b/src/clojars/web/login.clj
@@ -2,6 +2,7 @@
   (:require
    [clojars.web.common :refer [html-doc flash]]
    [clojars.web.safe-hiccup :refer [form-to]]
+   [clojars.web.helpers :as helpers]
    [clojure.string :as str]
    [hiccup.element :refer [link-to]]
    [hiccup.form :refer [label text-field
@@ -42,4 +43,6 @@
 
              (submit-button "Login")
              [:div#login-or "or"]
-             (link-to {:class :github-button} "/oauth/github/authorize" "Login with GitHub"))]))
+             (link-to {:class :github-button} "/oauth/github/authorize"
+                      (helpers/retinized-image "/images/github-mark.png" "GitHub")
+                      "Login with GitHub"))]))


### PR DESCRIPTION
I guess it would be nice to have a GitHub logo on that button so it would be easier and faster to understand what that means. I kind of didn't notice the project already had this before, so I just used the same `github-mark.png` that is used on the artifact page and just added a CSS invert filter.

![image](https://user-images.githubusercontent.com/6964593/99148437-5f296480-2666-11eb-9e3d-7c2926516e4b.png)
