### PR TITLE
Update Gradle dependency notation

### DIFF
--- a/src/clojars/web/jar.clj
+++ b/src/clojars/web/jar.clj
@@ -133,8 +133,9 @@
    [:div#gradle-coordinates.package-config-example
     {:onClick "selectText('gradle-coordinates');"}
     [:pre
-     "compile "
-     [:span.string \' group_name ":" jar_name ":" version \']]]))
+     "implementation("
+     [:span.string \" group_name ":" jar_name ":" version \"]
+     \)]]))
 
 (defn maven-coordinates [{:keys [group_name jar_name version]}]
   (list


### PR DESCRIPTION
This PR updates the dependency notation to be \
`implementation("group:artifact:version")`\
instead of\
`compile 'group:artifact:version'`.

**Why?**

- This notation is DSL-agnostic - the previous notation only works in the Groovy DSL, this works in both Groovy and Kotlin. 
- `compile` should not be used anymore - `implementation` was introduced in Gradle 3.4 as a better default that does not expose the dependency to sub-dependencies. Subsequently, `compile` was deprecated and now finally removed in the latest Gradle version, 7.0.