### PR TITLE
Remove verified badge for non-owned groups

### DIFF
--- a/src/clojars/db.clj
+++ b/src/clojars/db.clj
@@ -143,12 +143,6 @@
                                {:connection db
                                 :result-set-fn first}))
 
-(defn with-verified-group
-  [db {:as jar :keys [group_name]}]
-  (when jar
-    (assoc jar
-           :verified-group? (boolean (find-group-verification db group_name)))))
-
 (defn verify-group! [db username group-name]
   (when-not (find-group-verification db group-name)
     (sql/verify-group! {:group_name group-name
@@ -305,7 +299,7 @@
   (vec
    (map
     (fn [{:keys [group_name jar_name]}]
-      (with-verified-group db (find-jar db group_name jar_name)))
+      (find-jar db group_name jar_name))
     (all-projects db
                   (* (dec current-page) per-page)
                   per-page))))

--- a/src/clojars/routes/artifact.clj
+++ b/src/clojars/routes/artifact.clj
@@ -6,16 +6,14 @@
             [ring.util.response :as response]))
 
 (defn show [db stats group-id artifact-id]
-  (when-let [artifact (db/with-verified-group
-                        db
-                        (db/find-jar db group-id artifact-id))]
+  (when-some [artifact (db/find-jar db group-id artifact-id)]
     (auth/try-account
-      #(view/show-jar db
-                      stats
-                      %
-                      artifact
-                      (db/recent-versions db group-id artifact-id 5)
-                      (db/count-versions db group-id artifact-id)))))
+     #(view/show-jar db
+                     stats
+                     %
+                     artifact
+                     (db/recent-versions db group-id artifact-id 5)
+                     (db/count-versions db group-id artifact-id)))))
 
 (defn list-versions [db group-id artifact-id]
   (when-let [artifact (db/find-jar db group-id artifact-id)]
@@ -24,12 +22,11 @@
          (db/recent-versions db group-id artifact-id)))))
 
 (defn- show-version [db stats group-id artifact-id version]
-  (when-let [artifact (db/with-verified-group
-                        db (db/find-jar db group-id artifact-id version))]
+  (when-some [artifact (db/find-jar db group-id artifact-id version)]
     (auth/try-account
      #(view/show-jar db stats % artifact
-        (db/recent-versions db group-id artifact-id 5)
-        (db/count-versions db group-id artifact-id)))))
+                    (db/recent-versions db group-id artifact-id 5)
+                    (db/count-versions db group-id artifact-id)))))
 
 (defn response-based-on-format
   "render appropriate response based on the file type suffix provided:

--- a/src/clojars/web.clj
+++ b/src/clojars/web.clj
@@ -61,7 +61,7 @@
          #(let [validated-params (if (:page params)
                                    (assoc params :page (try-parse-page (:page params)))
                                    params)]
-            (search search-obj db % validated-params))))
+            (search search-obj % validated-params))))
    (GET "/projects" {:keys [params]}
         (try-account
          #(let [validated-params (if (:page params)

--- a/src/clojars/web/dashboard.clj
+++ b/src/clojars/web/dashboard.clj
@@ -19,9 +19,7 @@
   (let [max-id (db/max-jars-id db)]
     (if-let [jars (get @recent-jars-cache max-id)]
       jars
-      (let [jars (mapv
-                  (partial db/with-verified-group db)
-                  (db/recent-jars db))]
+      (let [jars (db/recent-jars db)]
         (reset! recent-jars-cache {max-id jars})
         jars))))
 

--- a/src/clojars/web/group.clj
+++ b/src/clojars/web/group.clj
@@ -21,7 +21,7 @@
                                               :name groupname}])
                [:div#group-title
                 [:h1 (str groupname " group")]
-                (when verified-group?
+                (when (and verified-group? show-membership-details?)
                   verified-group-badge-small)]
                [:h2 "Projects"]
                (unordered-list (map jar-link (jars-by-groupname db groupname)))

--- a/src/clojars/web/search.clj
+++ b/src/clojars/web/search.clj
@@ -1,14 +1,12 @@
 (ns clojars.web.search
   (:require
    [cheshire.core :as json]
-   [clojars.db :as db]
    [clojars.log :as log]
    [clojars.search :as search]
    [clojars.web.common :refer [html-doc jar-link jar-fork?
                                collection-fork-notice
                                format-date page-nav flash xml-escape
-                               jar-notice maven-search-link
-                               verified-group-badge]]
+                               jar-notice maven-search-link]]
    [clojars.web.error-api :as error-api]
    [clojure.string :as str]
    [clojure.xml :as xml]
@@ -117,7 +115,7 @@
       (artifact-id->group-id artifact-id) [(artifact-id->group-id artifact-id) artifact-id]
       :else false)))
 
-(defn html-search [search db account query page]
+(defn html-search [search account query page]
   (html-doc (str query " - search - page " page) {:account account :query query :description (format "Clojars search results page %d for '%s'" page query)}
             [:div.light-article.row
              [:h1 (format "Search for '%s'" query)]
@@ -142,15 +140,12 @@
                     (when (some jar-fork? results)
                       collection-fork-notice)
                     [:ul.row
-                     (for [{:keys [group-id artifact-id version created description]} results
-                           :let [verified-group? (boolean (db/find-group-verification db group-id))]]
+                     (for [{:keys [group-id artifact-id version created description]} results]
                        [:li.search-results.col-xs-12.col-sm-6.col-md-4.col-lg-3
                         [:div.result
                          [:div
                           [:div (jar-link {:jar_name artifact-id
                                            :group_name group-id}) " " version]]
-                         (when verified-group?
-                           [:div verified-group-badge])
                          [:br]
                          (when (seq description)
                            [:span.desc description
@@ -165,10 +160,10 @@
                (catch Exception _
                  [:p "Could not search; please check your query syntax."]))]))
 
-(defn search [search db account params]
+(defn search [search account params]
   (let [q (params :q)
         page (or (params :page) 1)]
     (case (params :format)
       "json" (json-search search q page)
       "xml"  (xml-search search q page)
-      (html-search search db account q page))))
+      (html-search search account q page))))


### PR DESCRIPTION
Showing the verified badge publicly for groups places a stigma on
legacy groups that can't be verified, and implies a false sense of
security for groups that are verified.

This removes the verified badge from the public view, only showing it
to a logged in user when they are viewing their own groups on their
dashboard page.