### PR TITLE
Send emails to all active group members when a deploy occurs

### DIFF
--- a/resources/public/stylesheets/screen.css
+++ b/resources/public/stylesheets/screen.css
@@ -140,7 +140,7 @@ footer a {
   margin: 0 5px;
 }
 
-.main-navigation {
+.navigation {
   text-align: right;
   font-weight: 600;
   font-size: 0.8em;
@@ -150,21 +150,39 @@ footer a {
   vertical-align: middle;
 }
 
-.main-navigation a {
-  color: #ffb33b;
+.navigation a {
   padding: 10px;
   border-radius: 10px;
   transition: background-color 0.2s ease-in-out;
 }
 
-.main-navigation a:hover {
-  background-color: rgba(255, 255, 255, 0.2);
+.navigation a:hover {
   text-decoration: none;
 }
 
-.main-navigation li {
+.navigation li {
   display: inline;
   margin-left: 15px;
+}
+
+.main-navigation a {
+  color: #ffb33b;
+}
+
+.main-navigation a:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+.secondary-navigation {
+  background-color: #e2e4e3;
+}
+
+.secondary-navigation a {
+  color: #380036;
+}
+
+.secondary-navigation a:hover {
+  background-color: rgba(0, 0, 0, 0.1);
 }
 
 .hero header .home h1 {
@@ -272,6 +290,7 @@ footer a {
 .small-section {
   max-width: 550px;
   margin: 0 auto 80px;
+  clear: both;
 }
 
 .push-example {

--- a/resources/queries/queryfile.sql
+++ b/resources/queries/queryfile.sql
@@ -358,6 +358,11 @@ UPDATE users
 SET email = :email, "user" = :username, password = :password, password_reset_code = NULL, password_reset_code_created_at = NULL
 WHERE "user" = :account;
 
+--name: update-user-notifications!
+UPDATE users
+SET send_deploy_emails = :send_deploy_emails
+WHERE "user" = :account;
+
 --name: reset-user-password!
 UPDATE users
 SET password = :password, password_reset_code = NULL, password_reset_code_created_at = NULL

--- a/resources/queries/queryfile.sql
+++ b/resources/queries/queryfile.sql
@@ -97,6 +97,22 @@ WHERE (
       inactive IS NOT true
 );
 
+--name: group-active-users
+SELECT u.*
+FROM users u
+JOIN (
+  SELECT "user"
+  FROM groups
+  WHERE (
+    name = :groupname
+    AND
+    inactive IS NOT true
+  )
+) g
+ON (
+  u.user = g.user
+)
+
 --name: group-allnames
 SELECT "user"
 FROM groups
@@ -329,8 +345,8 @@ FROM (
 WHERE group_name || '/' || jar_name < :s;
 
 --name: insert-user!
-INSERT INTO users (email, "user", password, created)
-VALUES (:email, :username, :password,:created);
+INSERT INTO users (email, "user", password, send_deploy_emails, created)
+VALUES (:email, :username, :password, :send_deploy_emails, :created);
 
 --name: update-user!
 UPDATE users

--- a/src/clojars/db.clj
+++ b/src/clojars/db.clj
@@ -61,6 +61,7 @@
     "maven"
     "mfa"
     "new"
+    "notification-preferences"
     "options"
     "pages"
     "password"
@@ -375,6 +376,10 @@
               (bcrypt password))
        {:connection db}))
     fields))
+
+(defn update-user-notifications [db account prefs]
+  (sql/update-user-notifications! (assoc prefs :account account)
+                                  {:connection db}))
 
 (defn reset-user-password [db username reset-code password]
   (assert (not (str/blank? reset-code)))

--- a/src/clojars/db.clj
+++ b/src/clojars/db.clj
@@ -346,6 +346,7 @@
   (let [record {:email email
                 :username username
                 :password (bcrypt password)
+                :send_deploy_emails true
                 :created (get-time)}]
     (sql/insert-user! record
                       {:connection db})

--- a/src/clojars/db.clj
+++ b/src/clojars/db.clj
@@ -201,6 +201,10 @@
                          {:connection db
                           :row-fn :user}))
 
+(defn group-active-users [db groupname]
+  (sql/group-active-users {:groupname groupname}
+                          {:connection db}))
+
 (defn group-allnames [db groupname]
   (sql/group-actives {:groupname groupname}
                      {:connection db

--- a/src/clojars/db/migrate.clj
+++ b/src/clojars/db/migrate.clj
@@ -97,6 +97,11 @@
   (sql/db-do-commands trans
                       "alter table deploy_tokens add expires_at timestamp"))
 
+(defn- add-send-deploy-emails-to-users
+  [trans]
+  (sql/db-do-commands trans
+                      "alter table users add send_deploy_emails boolean default false"))
+
 (def migrations
   [#'initial-schema
    #'add-deploy-tokens-table
@@ -107,7 +112,8 @@
    #'add-group-verifications-table
    #'add-audit-table
    #'add-single-use-to-tokens
-   #'add-expires-at-to-tokens])
+   #'add-expires-at-to-tokens
+   #'add-send-deploy-emails-to-users])
 
 (defn migrate [db]
   (sql/db-do-commands db

--- a/src/clojars/notifications.clj
+++ b/src/clojars/notifications.clj
@@ -13,12 +13,14 @@
   (mailer email title (str/join "\n\n" body)))
 
 (defn handler
-  [{:keys [db mailer]} type {:as data :keys [user-id username]}]
+  [{:keys [db mailer]} type {:as data :keys [user user-id username]}]
   (when (contains? (set (keys (methods notification))) type)
-    (let [user (if user-id
-                 (db/find-user-by-id db user-id)
-                 (db/find-user db username))]
-      (notification type mailer user data))))
+    (let [user' (cond
+                  user     user
+                  user-id  (db/find-user-by-id db user-id)
+                  username (db/find-user db username)
+                  :else    nil)]
+      (notification type mailer user' data))))
 
 (defn notification-component
   "Handles email notifications. Needs :db, :mailer."

--- a/src/clojars/notifications/deploys.clj
+++ b/src/clojars/notifications/deploys.clj
@@ -1,0 +1,22 @@
+(ns clojars.notifications.deploys
+  (:require
+   [clojars.notifications :as notifications]))
+
+(defn- version-url
+  [group name version]
+  (format "https://clojars.org/%s/%s/versions/%s"
+          group name version))
+
+(defmethod notifications/notification :version-deployed
+  [_type mailer
+   {:as _user email :email send-email? :send_deploy_emails}
+   {:keys [deployer-username group name version]}]
+  (when send-email?
+    (let [ga (format "%s/%s" group name)]
+      (notifications/send
+       mailer email (format "[Clojars] %s deployed %s %s" deployer-username ga version)
+       [(format
+         "User '%s' just deployed %s %s to Clojars: %s"
+         deployer-username ga version (version-url group name version))
+        "If you believe this is malicious activity, please reply to this email immediately and let the Clojars staff know!"
+        "You can turn off these notifications in your settings on https://clojars.org."]))))

--- a/src/clojars/routes/user.clj
+++ b/src/clojars/routes/user.clj
@@ -120,6 +120,13 @@
          (auth/with-account
            #(disable-mfa db % (db/find-user db %) params)))
 
+   (GET "/notification-preferences" {:keys [flash]}
+        (auth/with-account
+          #(view/notifications-form % (db/find-user db %) flash)))
+   (POST "/notification-preferences" {:keys [params]}
+         (auth/with-account
+           #(view/update-notifications db % params)))
+
    (GET "/register" {:keys [params flash]}
         (view/register-form params flash))
 

--- a/src/clojars/system.clj
+++ b/src/clojars/system.clj
@@ -3,6 +3,7 @@
    [clojars.email :refer [simple-mailer]]
    [clojars.notifications :as notifications]
    ;; for defmethods
+   [clojars.notifications.deploys]
    [clojars.notifications.mfa]
    [clojars.notifications.token]
    [clojars.oauth.github :as github]

--- a/src/clojars/web/common.clj
+++ b/src/clojars/web/common.clj
@@ -141,7 +141,8 @@
              [:div.row
               [:nav.navigation.secondary-navigation.col-xs-24.col-sm-12
                (unordered-list
-                [(link-to "/mfa" "two-factor auth")
+                [(link-to "/notification-preferences" "notification prefs")
+                 (link-to "/mfa" "two-factor auth")
                  (link-to "/profile" "profile")
                  (link-to "/tokens" "deploy tokens")])]])
            body

--- a/src/clojars/web/common.clj
+++ b/src/clojars/web/common.clj
@@ -129,17 +129,21 @@
                        :placeholder "Search projects..."
                        :value (:query ctx)
                        :required true}]]]
-            [:nav.main-navigation.col-xs-12.col-sm-6
+            [:nav.navigation.main-navigation.col-xs-12.col-sm-6
              (if (:account ctx)
                (unordered-list
                 [(link-to "/" "dashboard")
-                 (link-to "/mfa" "two-factor auth")
-                 (link-to "/profile" "profile")
-                 (link-to "/tokens" "deploy tokens")
                  (link-to "/logout" "logout")])
                (unordered-list
                 [(link-to "/login" "login")
                  (link-to "/register" "register")]))]]
+           (when (:account ctx)
+             [:div.row
+              [:nav.navigation.secondary-navigation.col-xs-24.col-sm-12
+               (unordered-list
+                [(link-to "/mfa" "two-factor auth")
+                 (link-to "/profile" "profile")
+                 (link-to "/tokens" "deploy tokens")])]])
            body
            (footer (get ctx :footer-links? true))]]))
 
@@ -194,7 +198,7 @@
              (link-to "/" (helpers/retinized-image "/images/clojars-logo.png" "Clojars"))
              [:h1
               (link-to "/" "Clojars")]]
-            [:nav.main-navigation.col-xs-12.col-sm-6
+            [:nav.navigation.main-navigation.col-xs-12.col-sm-6
              (if (:account ctx)
                (unordered-list
                 [(link-to "/" "dashboard")

--- a/test/clojars/integration/uploads_test.clj
+++ b/test/clojars/integration/uploads_test.clj
@@ -17,7 +17,7 @@
    [clojure.java.jdbc :as sql]
    [clojure.string :as str]
    [clojure.test :refer [are deftest is testing use-fixtures]]
-   [kerodon.core :refer [fill-in follow press session visit within]]
+   [kerodon.core :refer [fill-in follow press session uncheck visit within]]
    [kerodon.test :refer [has status? text?]]
    [net.cgrand.enlive-html :as enlive]
    [clojars.email :as email])
@@ -951,3 +951,32 @@
                   bodies))
       (is (every? #(re-find #"https://clojars.org/org.clojars.dantheman/test/versions/0.0.1" %)
                   bodies)))))
+
+(deftest deploy-sends-notification-emails-only-when-enabled
+  (-> (session (help/app-from-system))
+      (register-as "donthemon" "test2@example.org" "password")
+      (visit "/notification-preferences")
+      (uncheck "Receive deploy notification emails?")
+      (press "Update"))
+  (-> (session (help/app-from-system))
+      (register-as "dantheman" "test@example.org" "password")
+      (visit "/groups/org.clojars.dantheman")
+      (fill-in [:#username] "donthemon")
+      (press "Add Member"))
+  (let [token (create-deploy-token (session (help/app-from-system)) "dantheman" "password" "testing")]
+    (email/expect-mock-emails 1)
+    (deploy
+     {:coordinates '[org.clojars.dantheman/test "0.0.1"]
+      :jar-file (io/file (io/resource "test.jar"))
+      :pom-file (help/rewrite-pom (io/file (io/resource "test-0.0.1/test.pom"))
+                                  {:groupId "org.clojars.dantheman"})
+      :password token})
+
+    (is (true? (email/wait-for-mock-emails)))
+    (let [emails @email/mock-emails
+          [[address title body]] emails]
+      (is (= 1 (count emails)))
+      (is (= "test@example.org" address))
+      (is (= "[Clojars] dantheman deployed org.clojars.dantheman/test 0.0.1" title))
+      (is (re-find #"User 'dantheman' just deployed org.clojars.dantheman/test 0.0.1" body))
+      (is (re-find #"https://clojars.org/org.clojars.dantheman/test/versions/0.0.1" body)))))

--- a/test/clojars/integration/uploads_test.clj
+++ b/test/clojars/integration/uploads_test.clj
@@ -19,7 +19,8 @@
    [clojure.test :refer [are deftest is testing use-fixtures]]
    [kerodon.core :refer [fill-in follow press session visit within]]
    [kerodon.test :refer [has status? text?]]
-   [net.cgrand.enlive-html :as enlive])
+   [net.cgrand.enlive-html :as enlive]
+   [clojars.email :as email])
   (:import
    (java.sql Timestamp)
    (org.eclipse.aether.deployment
@@ -920,3 +921,33 @@
     (let [{:keys [token_hash]} (db/find-token-by-value db token)]
       (is (= (db/hash-deploy-token token)
              token_hash)))))
+
+(deftest deploy-sends-notification-emails
+  (-> (session (help/app-from-system))
+      (register-as "donthemon" "test2@example.org" "password"))
+  (-> (session (help/app-from-system))
+      (register-as "dantheman" "test@example.org" "password")
+      (visit "/groups/org.clojars.dantheman")
+      (fill-in [:#username] "donthemon")
+      (press "Add Member"))
+  (let [token (create-deploy-token (session (help/app-from-system)) "dantheman" "password" "testing")]
+    (email/expect-mock-emails 2)
+    (deploy
+     {:coordinates '[org.clojars.dantheman/test "0.0.1"]
+      :jar-file (io/file (io/resource "test.jar"))
+      :pom-file (help/rewrite-pom (io/file (io/resource "test-0.0.1/test.pom"))
+                                  {:groupId "org.clojars.dantheman"})
+      :password token})
+
+    (is (true? (email/wait-for-mock-emails)))
+    (let [emails @email/mock-emails
+          addresses (into #{} (map first) emails)
+          titles (map second emails)
+          bodies (map #(nth % 2) emails)]
+      (is (= #{"test@example.org" "test2@example.org"} addresses))
+      (is (every? #(= "[Clojars] dantheman deployed org.clojars.dantheman/test 0.0.1" %)
+                  titles))
+      (is (every? #(re-find #"User 'dantheman' just deployed org.clojars.dantheman/test 0.0.1" %)
+                  bodies))
+      (is (every? #(re-find #"https://clojars.org/org.clojars.dantheman/test/versions/0.0.1" %)
+                  bodies)))))


### PR DESCRIPTION
This addresses #153, but isn't yet complete since there is no UI to turn the option on for existing users.