### PR TITLE
Drop jar assertion when validating deploys

### DIFF
--- a/src/clojars/routes/repo.clj
+++ b/src/clojars/routes/repo.clj
@@ -217,12 +217,6 @@
           (throw-invalid :central-shadow
                          "shadowing Maven Central artifacts is not allowed. See https://bit.ly/3rTLqxZ"
             meta))))))
- 
-(defn assert-jar-uploaded [artifacts pom]
-  (when (and (= :jar (:packaging pom))
-          (not (some (partial match-file-name #"\.jar$") artifacts)))
-    (throw-invalid :missing-jar-file
-                   "no jar file was uploaded")))
 
 (defn validate-checksums [artifacts]
   (doseq [f artifacts]
@@ -276,7 +270,6 @@
   (assert-non-central-shadow group name)
 
   (let [artifacts (find-artifacts dir)]
-    (assert-jar-uploaded artifacts pom)
     (validate-checksums artifacts)
     (assert-signatures (remove (partial match-file-name "maven-metadata.xml") artifacts))))
 


### PR DESCRIPTION
This PR follows from the discussion in #801. To summarize:

* It would be nice to support maven style relocations
* Supporting proper maven style relocations comes with its own set of problems (such as having to overwrite old poms, cache invalidation, etc.)
* Instead of going all-in, let's take a small first step of allowing pom-only deploys. This gives us some flexibility in the following cases:
  * If tooling in the future supports Maven's relocation fully, a pom-only deployment for a new version of a library can use that to indicate relocation (this can also be picked up by UI). `lein` supports this already but tools.deps doesn't.
  * A pom-only deployment that specifies relocated coordinates as a dependency. Tooling that doesn't support relocation can still pick this up and put it on the classpath. We may have to add custom logic to drive the UI. One suggestion that exists is to build a convention for pom description field and parse that. This will be addressed separately.