### PR TITLE
Add alternative badge that includes prereleases

### DIFF
--- a/src/clojars/http_utils.clj
+++ b/src/clojars/http_utils.clj
@@ -40,8 +40,8 @@
    ";"
    ;; Load anything from the clojars domain
    ["default-src 'self'"
-    ;; Load images from clojars domain along with dnsimple's logo
-    "img-src 'self' https://cdn.dnsimple.com"]))
+    ;; Load images from clojars domain along with dnsimple's logo and badges from shields.io
+    "img-src 'self' https://cdn.dnsimple.com https://img.shields.io"]))
 
 (def ^:private permissions-policy
   ;; We need zero features

--- a/src/clojars/web/jar.clj
+++ b/src/clojars/web/jar.clj
@@ -78,14 +78,21 @@
   [{:as dep :keys [version]}]
   (safe-link-to (jar-versioned-url dep) version))
 
-(defn version-badge-url [jar]
-  (format "https://img.shields.io/clojars/v%s.svg" (jar-url jar)))
+(defn version-badge-url [jar include-prereleases]
+  (str
+    (format "https://img.shields.io/clojars/v%s.svg" (jar-url jar))
+    (when include-prereleases
+      "?include_prereleases")))
 
-(defn badge-markdown [jar]
+(defn badge-markdown [jar include-prereleases]
   (format
    "[![Clojars Project](%s)](https://clojars.org%s)"
-   (version-badge-url jar)
+   (version-badge-url jar include-prereleases)
    (jar-url jar)))
+
+(defn badge-img [jar include-prereleases]
+  [:img
+   {:src (version-badge-url jar include-prereleases)}])
 
 (defn fork-notice [jar]
   (when (jar-fork? jar)
@@ -265,11 +272,18 @@
    [:h4 "Version Badge"]
    [:p
     "Want to display the "
-    (link-to (version-badge-url jar) "latest version")
+    (link-to (version-badge-url jar false) "latest version")
     " of your project on GitHub? Use the markdown code below!"]
+   (badge-img jar false)
    [:textarea#version-badge.select-text
-    {:readonly "readonly" :rows 6}
-    (badge-markdown jar)]))
+    {:readonly "readonly" :rows 4}
+    (badge-markdown jar false)]
+   [:p
+    "If you want to include pre-releases and snapshots, use the following markdown code:"]
+   (badge-img jar true)
+   [:textarea#version-badge.select-text
+    {:readonly "readonly" :rows 4}
+    (badge-markdown jar true)]))
 
 (defn show-jar [db stats account
                 {:keys [group_name jar_name verified-group? version] :as jar}


### PR DESCRIPTION
Also adds showing of the badges next to the markdown code so users can
see what they are including. This means adding an exception to CSP for
img.shields.io as well.

Resolves issue #332

This is how the section looks after applying this patch:

![image](https://user-images.githubusercontent.com/459764/173639500-09402aad-031c-48b8-b556-c4a32861ebda.png)
