### PR TITLE
Clean up slf4j dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -66,7 +66,8 @@
                  [org.postgresql/postgresql "42.3.3"]
                  [duct/hikaricp-component "0.1.2"
                   :exclusions [com.stuartsierra/component
-                               org.slf4j/slf4j-api]]
+                               org.slf4j/slf4j-api
+                               org.slf4j/slf4j-nop]]
                  [duct "0.8.2"
                   :exclusions [org.clojure/tools.reader]]
                  [ring/ring-core "1.9.4"]
@@ -91,6 +92,8 @@
                  [org.clojure/tools.logging "1.2.3"]
                  [ch.qos.logback/logback-classic "1.3.0-alpha5"
                   :exclusions [com.sun.mail/javax.mail]]
+                 ;; Upgrading for compatibility with logback 1.3.x
+                 [org.slf4j/jcl-over-slf4j "2.0.0-alpha1"]
                  
                  ;; AWS
                  [com.cognitect.aws/api "0.8.539"]
@@ -135,6 +138,7 @@
                                   [net.polyc0l0r/bote "0.1.0"
                                    :exclusions [commons-codec
                                                 javax.mail/mail
+                                                org.clojars.kjw/slf4j
                                                 org.clojars.kjw/slf4j-simple]]
                                   [nubank/matcher-combinators "3.3.1"
                                    ;; we don't use midje, so excluding it to


### PR DESCRIPTION
I was trying to set up my dev environment locally and couldn't start a REPL. I was getting the exception below, which seemed likely to be some kind of SLF4J mismatch. It may not have cropped up on others due to classpath ordering differences, I'm not positive if Leiningen does anything special to work around that.

Looking through the deps tree, I found a few dependencies that were pulling in other SLF4J libs that were quite different versions from the 2.0.0-alpha1 pulled in by your explicit dep on logback.

This has removed the SLF4J fork pulled in by bote and the slf4j-nop which is pulled in by Duct's hikari component (which kinda seems like a bug on their side).

The remaining jcl dep may be needed to route logs into logback, so I bumped the version to align with the logback dep's slf4j version.

```
Caused by: java.lang.IllegalAccessError: class org.slf4j.LoggerFactory tried to access private field org.slf4j.impl.StaticLoggerBinder.SINGLETON (org.slf4j.LoggerFactory and org.slf4j.impl.StaticLoggerBinder are in
unnamed module of loader 'app')
```