### PR TITLE
Allow .module files to be uploaded

### DIFF
--- a/dev-resources/test-0.0.1/test.module
+++ b/dev-resources/test-0.0.1/test.module
@@ -1,0 +1,98 @@
+{
+  "formatVersion": "1.1",
+  "component": {
+    "group": "org.clojars.dantheman",
+    "module": "test",
+    "version": "0.0.1",
+    "attributes": {
+      "org.gradle.status": "release"
+    }
+  },
+  "createdBy": {
+    "gradle": {
+      "version": "7.5"
+    }
+  },
+  "variants": [
+    {
+      "name": "apiElements",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.jvm.version": 8,
+        "org.gradle.libraryelements": "jar",
+        "org.gradle.usage": "java-api"
+      },
+      "dependencies": [
+        {
+          "group": "org.clojure",
+          "module": "clojure",
+          "version": {
+            "requires": "1.11.1"
+          }
+        }
+      ],
+      "files": [
+        {
+          "name": "test-0.0.1.jar",
+          "url": "test-0.0.1.jar",
+          "size": 2428217,
+          "sha512": "8d91ee40ee15aff5fe274bdba9f771d38658758dedc599f6fa8e56499e777e07cef1016268ed9c337e4e01cd7d3a5c41f390236bc603b44d86af355f0a8305e4",
+          "sha256": "f49dd73524a12998f51a8ca3c1b41aba4f541b85e7512af61dee8402b16178f7",
+          "sha1": "37b7cc86f42eaaf1c16f7963384529f4b1983edd",
+          "md5": "30071f5cf2584b28f1f57c09d4299275"
+        }
+      ]
+    },
+    {
+      "name": "runtimeElements",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.jvm.version": 8,
+        "org.gradle.libraryelements": "jar",
+        "org.gradle.usage": "java-runtime"
+      },
+      "dependencies": [
+        {
+          "group": "org.clojure",
+          "module": "clojure",
+          "version": {
+            "requires": "1.11.1"
+          }
+        }
+      ],
+      "files": [
+        {
+          "name": "test-0.0.1.jar",
+          "url": "test-0.0.1.jar",
+          "size": 2428217,
+          "sha512": "8d91ee40ee15aff5fe274bdba9f771d38658758dedc599f6fa8e56499e777e07cef1016268ed9c337e4e01cd7d3a5c41f390236bc603b44d86af355f0a8305e4",
+          "sha256": "f49dd73524a12998f51a8ca3c1b41aba4f541b85e7512af61dee8402b16178f7",
+          "sha1": "37b7cc86f42eaaf1c16f7963384529f4b1983edd",
+          "md5": "30071f5cf2584b28f1f57c09d4299275"
+        }
+      ]
+    },
+    {
+      "name": "sourcesElements",
+      "attributes": {
+        "org.gradle.category": "documentation",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.docstype": "sources",
+        "org.gradle.usage": "java-runtime"
+      },
+      "files": [
+        {
+          "name": "test-0.0.1-sources.jar",
+          "url": "test-0.0.1-sources.jar",
+          "size": 7749,
+          "sha512": "e10939a71913a3d950ed450bb5977614263bb8c87346933f15533b16f876bdd93fab7b084ccf250b1d5529343766beed52dbbfbe9aa0ed1af16830b60f30b9e2",
+          "sha256": "23b994f991a9f40dd3f3b38a77a6c5dd871c75c99718009ce58cbb02232e606d",
+          "sha1": "88488cb57ab2800806b99fef9eb533bfaea62ac2",
+          "md5": "e9f1db605098f6514deb6c4aace01495"
+        }
+      ]
+    }
+  ]
+}

--- a/src/clojars/gradle.clj
+++ b/src/clojars/gradle.clj
@@ -1,0 +1,9 @@
+(ns clojars.gradle
+  (:require [cheshire.core :as json]
+            [clojure.java.io :as io]))
+
+(defn module-to-map
+  "Reads a Gradle module file returning a map"
+  [file]
+  (with-open [reader (io/reader file)]
+    (json/parse-stream reader true)))

--- a/src/clojars/routes/repo.clj
+++ b/src/clojars/routes/repo.clj
@@ -157,10 +157,7 @@
            :body nil})))))
 
 (defn find-pom [dir]
-  (->> dir
-    file-seq
-    (filter pom?)
-    first))
+  (util/filter-some pom? (file-seq dir)))
 
 (defn find-module [dir]
   (util/filter-some module? (file-seq dir)))


### PR DESCRIPTION
Gradle module files [1] are Gradle's alternative to POM files. They have a similar goal of defining the primary component
group/artifact/version that was published along with its dependencies. Additionally they allow declaring variants of the main
component that may have different dependencies or capabilities.

We're doing very minimal validation, parsing it as JSON and validating the top-level component group/module/version the upload path (as is already done for POM files).

It does look like Gradle uploads `maven-metadata.xml` last, so I believe this should fit in with how the existing validation works. I _think_ [this is the line in Gradle's code](https://github.com/gradle/gradle/blob/1e1785d8f5b4f5a2068c9ec992bdd830a43b86bf/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java#L92) that implies the order.

[1] https://docs.gradle.org/current/userguide/publishing_gradle_module_metadata.html

Fixes #835

This was my first crack at it. Open to any feedback or changes that you'd like to see.