### PR TITLE
Verify io VCS groups instead of net

### DIFF
--- a/src/clojars/web/group_verification.clj
+++ b/src/clojars/web/group_verification.clj
@@ -71,9 +71,9 @@
       [:code "https://github.com/example-org/"] " or "
       [:code "https://gitlab.com/example-org/"] ", you can have the groups "
       [:code "com.github.example-org"] " & "
-      [:code "net.github.example-org"] " or "
+      [:code "io.github.example-org"] " or "
       [:code "com.gitlab.example-org"] " & "
-      [:code "net.gitlab.example-org"] ", respectively."]
+      [:code "io.gitlab.example-org"] ", respectively."]
      [:p
       " You can verify ownership of the organization by creating
       a " [:strong "public"] " repo named "

--- a/test/clojars/integration/group_verification_test.clj
+++ b/test/clojars/integration/group_verification_test.clj
@@ -59,23 +59,23 @@
 (deftest user-can-verify-sub-group
   (help/with-TXT ["clojars dantheman"]
     (let [sess (-> (session)
-                  (visit "/verify/group")
-                  (within [:div.via-txt]
-                          (fill-in "Group name" "com.example")
-                          (fill-in "Domain with TXT record" "example.com")
-                          (press "Verify Group"))
-                  (follow-redirect)
-                  (within [:div.info]
-                          (has (some-text? "The group 'com.example' has been verified"))))]
+                   (visit "/verify/group")
+                   (within [:div.via-txt]
+                     (fill-in "Group name" "com.example")
+                     (fill-in "Domain with TXT record" "example.com")
+                     (press "Verify Group"))
+                   (follow-redirect)
+                   (within [:div.info]
+                     (has (some-text? "The group 'com.example' has been verified"))))]
       (assert-admin-email :success)
       (email/expect-mock-emails 1)
       (-> sess
           (within [:div.via-parent]
-                  (fill-in "Group name" "com.example.ham")
-                  (press "Verify Group"))
+            (fill-in "Group name" "com.example.ham")
+            (press "Verify Group"))
           (follow-redirect)
           (within [:div.info]
-                  (has (some-text? "The group 'com.example.ham' has been verified"))))
+            (has (some-text? "The group 'com.example.ham' has been verified"))))
       (assert-admin-email :success))))
 
 (deftest user-cannot-verify-subgroup-with-non-verified-parent
@@ -99,7 +99,7 @@
           (press "Verify Groups"))
         (follow-redirect)
         (within [:div.info]
-          (has (some-text? "The groups 'com.github.example' & 'net.github.example' have been verified"))))
+          (has (some-text? "The groups 'com.github.example' & 'io.github.example' have been verified"))))
     (assert-admin-email :success)))
 
 (deftest user-cannot-verify-vcs-groups-with-missing-repo

--- a/test/clojars/unit/verification_test.clj
+++ b/test/clojars/unit/verification_test.clj
@@ -180,7 +180,7 @@
 
 (deftest verify-vcs-groups-with-already-verified-groups
   (db/verify-group! help/*db* "dantheman" "com.github.foo")
-  (db/verify-group! help/*db* "dantheman" "net.github.foo")
+  (db/verify-group! help/*db* "dantheman" "io.github.foo")
   (is (match?
        {:error (format "Groups already verified by user 'dantheman' on %s."
                        (common/format-date (Date.)))}
@@ -188,10 +188,10 @@
                                          :username "dantheman"}))))
 
 (deftest verify-vcs-groups-with-non-existent-repo
-  (doseq [responders [(constantly {:status 404})
-                      (constantly {:status 302})
-                      (fn [& _] (throw (ex-info "BOOM" {})))]]
-    (with-redefs [http/head responders]
+  (doseq [responder [(constantly {:status 404})
+                     (constantly {:status 302})
+                     (fn [& _] (throw (ex-info "BOOM" {})))]]
+    (with-redefs [http/head responder]
       (is (match?
            {:error "The verification repo does not exist."}
            (nut/verify-vcs-groups help/*db* {:url      "https://github.com/foo/clojars-dantheman"
@@ -200,6 +200,6 @@
 (deftest verify-vcs-groups-when-the-repo-exists
   (with-redefs [http/head (constantly {:status 200})]
     (is (match?
-         {:message "The groups 'com.github.foo' & 'net.github.foo' have been verified."}
+         {:message "The groups 'com.github.foo' & 'io.github.foo' have been verified."}
          (nut/verify-vcs-groups help/*db* {:url      "https://github.com/foo/clojars-dantheman"
                                            :username "dantheman"})))))


### PR DESCRIPTION
This was a mistake introduced with self-verification; we should have
always verified the io domains.

See #864.