### PR TITLE
Use SQS for events instead of tap

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,13 @@ jobs:
             - $HOME/.m2
             - $HOME/.lein
           key: clojars-{{ checksum "project.clj" }}
+      - run:
+          name: Download ElasticMQ
+          command: wget https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-1.4.2.jar -O elasticmq.jar
+      - run:
+          name: Run ElasticMQ
+          command: java -Dconfig.file=dev-resources/elasticmq.conf -jar elasticmq.jar
+          background: true
       - run: lein do run -m user/migrate, test, uberjar
       - run: ./bin/clj-kondo --lint src test
       - store_test_results:

--- a/dev-resources/elasticmq.conf
+++ b/dev-resources/elasticmq.conf
@@ -1,0 +1,10 @@
+include classpath("application.conf")
+
+queues {
+  clojars-events {
+    defaultVisibilityTimeout = 60 seconds
+    # This is 20s in production, but we don't want to wait that long to shut down the system in
+    # testing
+    receiveMessageWait = 0 seconds
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,3 +29,13 @@ services:
     environment:
       MINIO_ROOT_USER: fake-access-key
       MINIO_ROOT_PASSWORD: fake-secret-key
+  elasticmq:
+    image: "softwaremill/elasticmq:1.4.2"
+    ports:
+      - "9324:9324"
+      - "9325:9325"
+    volumes:
+      - type: bind
+        source: ./dev-resources/elasticmq.conf
+        target: /opt/elasticmq.conf
+        read_only: true

--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,8 @@
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [org.clojure/core.memoize "1.0.253"]
                  ;; manage jetty dependencies directly to make it easier to address CVEs
-                 [org.eclipse.jetty/jetty-client "9.4.49.v20220914"]
-                 [org.eclipse.jetty/jetty-server "9.4.49.v20220914"]
+                 [org.eclipse.jetty/jetty-client "9.4.51.v20230217"]
+                 [org.eclipse.jetty/jetty-server "9.4.51.v20230217"]
                  ;; manage jackson-databind directly to make it easiser to address CVEs
                  [com.fasterxml.jackson.core/jackson-databind "2.14.0-rc1"]
                  [raven-clj "1.6.0"
@@ -98,10 +98,11 @@
                  [org.slf4j/jcl-over-slf4j "2.0.0-alpha1"]
 
                  ;; AWS
-                 [com.cognitect.aws/api "0.8.635"]
-                 [com.cognitect.aws/endpoints "1.1.12.373"]
-                 [com.cognitect.aws/s3 "825.2.1250.0"]
-                 [com.cognitect.aws/ssm "825.2.1283.0"]]
+                 [com.cognitect.aws/api "0.8.681"]
+                 [com.cognitect.aws/endpoints "1.1.12.489"]
+                 [com.cognitect.aws/s3 "847.2.1398.0"]
+                 [com.cognitect.aws/sqs "847.2.1398.0"]
+                 [com.cognitect.aws/ssm "847.2.1365.0"]]
   :plugins [[supersport "1"]]
   :main ^:skip-aot clojars.main
   :target-path "target/%s/"

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -18,6 +18,14 @@
                                            :default    "clojars"}}
  :deletion-backup-dir #profile {:production "/home/clojars/repo-deleted"
                                 :default    "data/test/repo-backup"}
+ :event-queue         #profile {:production {:queue-url "https://sqs.us-east-2.amazonaws.com/825662292780/clojars-events"}
+                                :default    {:credentials {:access-key-id     "fake-access-key"
+                                                           :secret-access-key "fake-secret-key"}
+                                             :endpoint {:protocol "http"
+                                                        :hostname "localhost"
+                                                        :port     9324}
+                                             :region "us-east-1"
+                                             :queue-url "http://localhost:9324/000000000000/clojars-events"}}
  :github-oauth        {:client-id     #profile {:production #ssm-parameter "/clojars/production/github_oauth_client_id"
                                                 :default    "testing"}
                        :client-secret #profile {:production #ssm-parameter "/clojars/production/github_oauth_client_secret"

--- a/src/clojars/aws_util.clj
+++ b/src/clojars/aws_util.clj
@@ -1,0 +1,18 @@
+(ns clojars.aws-util
+  (:require
+   [cognitect.aws.client.api :as aws]))
+
+(defn- throw-on-error
+  [v]
+  (if (some? (:cognitect.anomalies/category v))
+    (throw (ex-info "AWS request failed" v))
+    v))
+
+(defn invoke
+  [client op request]
+  (throw-on-error (aws/invoke client {:op op :request request})))
+
+(defn not-found->nil
+  [v]
+  (when (not= :cognitect.anomalies/not-found (:cognitect.anomalies/category v))
+    v))

--- a/src/clojars/event.clj
+++ b/src/clojars/event.clj
@@ -1,14 +1,96 @@
 (ns clojars.event
-  "Rudimentary event emission and handling using tap>."
+  "Event emission and handling using SQS."
   (:require
+   [clojars.aws-util :as aws-util]
+   [clojars.errors :as errors]
+   [clojure.edn :as edn]
+   [cognitect.aws.client.api :as aws]
+   [cognitect.aws.credentials :as credentials]
    [com.stuartsierra.component :as component]))
+
+(defn- sqs-client
+  [{:as _config :keys [credentials endpoint region]}]
+  (doto (aws/client (cond-> {:api :sqs}
+                      credentials (assoc :credentials-provider (credentials/basic-credentials-provider credentials))
+                      endpoint    (assoc :endpoint-override endpoint)
+                      region      (assoc :region region)))
+    (aws/validate-requests true)))
+
+(defprotocol EventEmitter
+  (-emit [this payload]))
+
+(defrecord SQSEmitter [config]
+  component/Lifecycle
+  (start [this]
+    (assoc this
+           :sqs-client (sqs-client config)))
+  (stop [this] this)
+
+  EventEmitter
+  (-emit [this payload]
+    (aws-util/invoke (:sqs-client this) :SendMessage
+                     {:QueueUrl (:queue-url config)
+                      :MessageBody (binding [*print-length* nil]
+                                     (pr-str payload))})
+    true))
+
+(defonce ^:private handlers (atom {}))
+
+(defn- sqs-receive-loop
+  [running? error-reporter sqs-client queue-url]
+  (while @running?
+    (try
+      ;; This will sleep up to 20s waiting on a message
+      (let [res (aws-util/invoke sqs-client :ReceiveMessage
+                                 {:QueueUrl queue-url})]
+        (doseq [{:keys [Body ReceiptHandle]} (:Messages res)
+                :let [event (edn/read-string Body)]]
+          (doseq [handler (vals @handlers)]
+            ;; This inner try/catch catches the failure of a single handler. If
+            ;; we let this bubble out, we wouldn't delete the message, and risk
+            ;; running all the handlers again when possibly just one is failing.
+            (try
+              (handler event)
+              (catch Exception e
+                (errors/report-error error-reporter e))))
+          ;; We don't consider handler failures worthy of retrying, given the
+          ;; risk of rerunning handlers, so we always delete the message if we
+          ;; make it this far. This means that in practice we'll never redrive a
+          ;; message, since this delete will only not get called if we can't edn
+          ;; parse the message.
+          (aws-util/invoke sqs-client :DeleteMessage
+                           {:QueueUrl queue-url
+                            :ReceiptHandle ReceiptHandle})))
+      (catch Exception e
+        (errors/report-error error-reporter e)))))
+
+(defrecord SQSReceiver [error-reporter config]
+  component/Lifecycle
+  (start [this]
+    (let [running? (atom true)]
+      (assoc this
+             :running? running?
+             :thread (future
+                       (sqs-receive-loop running? error-reporter
+                                         (sqs-client config) (:queue-url config))))))
+  (stop [this]
+    (reset! (:running? this) false)
+    (deref (:thread this) 60000 ::timeout)
+    this))
+
+(defn new-sqs-receiver
+  [config]
+  (map->SQSReceiver {:config config}))
 
 (defn emit
   "Emits an event of `type` with `data`. Returns true if the event was
   successfully queued."
-  [type data]
-  (tap> {::type type
-         ::data data}))
+  [emitter type data]
+  (-emit emitter {::type type ::data data}))
+
+(defn new-sqs-emitter
+  [config]
+  (map->SQSEmitter {:config config}))
 
 (defn- wrap
   [f]
@@ -20,22 +102,24 @@
   passed the type of the event and the event data. Returns a value
   that can be passed to `remove-handler` to remove the handler."
   [f]
-  (let [f (wrap f)]
-    (add-tap f)
-    f))
+  (let [f (wrap f)
+        key (gensym "event-handler")]
+    (swap! handlers assoc key f)
+    key))
 
-(def remove-handler
+(defn remove-handler
   "Removes an event handler. Should be passed the return value of `add-handler`."
-  remove-tap)
+  [key]
+  (swap! handlers dissoc key)
+  nil)
 
-(defrecord EventHandler
-           [handler]
+(defrecord EventHandler [handler]
   component/Lifecycle
   (start [this]
-    (assoc this :f (add-handler (partial handler this))))
-  (stop [{:as this :keys [f]}]
-    (remove-handler f)
-    (dissoc this :f)))
+    (assoc this :key (add-handler (partial handler this))))
+  (stop [{:as this :keys [key]}]
+    (remove-handler key)
+    (dissoc this :key)))
 
 (defn handler-component
   "Returns a new event handler component. `handler` is a three arg

--- a/test/clojars/integration/api_test.clj
+++ b/test/clojars/integration/api_test.clj
@@ -32,7 +32,7 @@
   (is (= (help/get-content-type {:headers {"content-type" "application/json;charset=utf-8"}}) "application/json")))
 
 (deftest an-api-test
-  (-> (session (help/app-from-system))
+  (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password"))
   (inject-artifacts-into-repo! (get-in help/system [:db :spec]) "dantheman" "test.jar" "test-0.0.1/test.pom")
   (inject-artifacts-into-repo! (get-in help/system [:db :spec]) "dantheman" "test.jar" "test-0.0.2/test.pom")

--- a/test/clojars/integration/group_verification_test.clj
+++ b/test/clojars/integration/group_verification_test.clj
@@ -10,11 +10,11 @@
    [kerodon.test :refer [has some-text?]]))
 
 (use-fixtures :each
-  help/with-test-system*)
+  help/run-test-app)
 
 (defn session
   []
-  (let [session (-> (kerodon/session (help/app-from-system))
+  (let [session (-> (kerodon/session (help/app))
                     (register-as "dantheman" "test@example.org" "password"))]
     (email/expect-mock-emails 1)
     session))

--- a/test/clojars/integration/jars_test.clj
+++ b/test/clojars/integration/jars_test.clj
@@ -10,7 +10,8 @@
 
 (use-fixtures :each
   help/default-fixture
-  help/with-clean-database)
+  help/with-clean-database
+  help/run-test-app)
 
 (deftest jars-can-be-viewed
   (inject-artifacts-into-repo! help/*db* "someuser" "test.jar" "test-0.0.1/test.pom")

--- a/test/clojars/integration/responses_test.clj
+++ b/test/clojars/integration/responses_test.clj
@@ -6,7 +6,8 @@
    [kerodon.test :refer [has status? text?]]))
 
 (use-fixtures :each
-  help/with-clean-database)
+  help/with-clean-database
+  help/run-test-app)
 
 (deftest respond-404
   (-> (session (help/app))

--- a/test/clojars/integration/sessions_test.clj
+++ b/test/clojars/integration/sessions_test.clj
@@ -14,7 +14,8 @@
 
 (use-fixtures :each
   help/default-fixture
-  help/with-clean-database)
+  help/with-clean-database
+  help/run-test-app)
 
 (deftest user-cant-login-with-bad-user-pass-combo
   (-> (session (help/app))

--- a/test/clojars/integration/web_test.clj
+++ b/test/clojars/integration/web_test.clj
@@ -12,7 +12,8 @@
 
 (use-fixtures :each
   help/default-fixture
-  help/with-clean-database)
+  help/with-clean-database
+  help/run-test-app)
 
 (deftest server-errors-display-error-page
   (with-out-str (-> (session (help/app))

--- a/test/clojars/test_helper.clj
+++ b/test/clojars/test_helper.clj
@@ -8,11 +8,9 @@
    [clojars.email :as email]
    [clojars.errors :as errors]
    [clojars.oauth.service :as oauth-service]
-   [clojars.remote-service :as remote-service]
    [clojars.s3 :as s3]
    [clojars.search :as search]
    [clojars.stats :as stats]
-   [clojars.storage :as storage]
    [clojars.system :as system]
    [clojars.web :as web]
    [clojure.java.io :as io]
@@ -108,32 +106,12 @@
 (defn memory-index []
   (RAMDirectory.))
 
-(defn app
-  ([] (app {}))
-  ([{:keys [storage db error-reporter http-client stats search mailer github]
-     :or {db {:spec *db*}
-          storage (storage/fs-storage (:repo (config/config)))
-          error-reporter (quiet-reporter)
-          http-client (remote-service/new-mock-remote-service)
-          stats (no-stats)
-          search (no-search)
-          mailer nil}}]
-   (web/clojars-app
-    {:db db
-     :error-reporter error-reporter
-     :http-client http-client
-     :github github
-     :mailer mailer
-     :search search
-     :stats stats
-     :storage storage})))
-
 (declare ^:dynamic system)
 
-(defn app-from-system []
+(defn app []
   (web/clojars-app system))
 
-(defn with-test-system*
+(defn- with-test-system*
   [f]
   (binding [config/*profile* "test"]
     ;; double binding since ^ needs to be bound for config to load
@@ -153,10 +131,6 @@
           (f)
           (finally
             (component/stop system)))))))
-
-(defmacro with-test-system
-  [& body]
-  `(with-test-system* #(do ~@body)))
 
 (defn run-test-app
   [f]

--- a/test/clojars/unit/web_test.clj
+++ b/test/clojars/unit/web_test.clj
@@ -6,7 +6,8 @@
 
 (use-fixtures :each
   help/default-fixture
-  help/with-clean-database)
+  help/with-clean-database
+  help/run-test-app)
 
 (defn cookies [res]
   (flatten [(get-in res [:headers "Set-Cookie"])]))


### PR DESCRIPTION
### Always use system-derived app in tests

We had two ways to init an app component for testing. This removes the
old way in favor of using a system-derived one everywhere.

### Extract aws invoke wrapper & error handler to util

This allows us to use it other places.

### Add SQS to docker compose

This allows us to develop against SQS.

### Update to latest cognitect.aws

### Use SQS for events instead of tap

This moves us to SQS for event emission and handling instead of using
tap. This helps reduce the risk that events will be lost (which can
happen if the process dies/is killed while there are events on the tap
queue).