### PR TITLE
Generate repo index files on deploy

### DIFF
--- a/src/clojars/email.clj
+++ b/src/clojars/email.clj
@@ -46,12 +46,14 @@
      (reset! email-latch (CountDownLatch. n))))
 
   (defn wait-for-mock-emails
-    "Blocks for up to 100ms waiting for `n` emails to be sent via the mock,
-  where `n` was passed to `expect-mock-emails` (defaulting to 1 if not called).
-  Returns true if `n` reached within that time. Reset with `expect-mock-emails`
-  between tests using the same system."
-    []
-    (.await @email-latch 100 TimeUnit/MILLISECONDS))
+    "Blocks for up to `wait-ms` (default: 100ms) waiting for `n` emails to be sent
+  via the mock, where `n` was passed to `expect-mock-emails` (defaulting to 1 if
+  not called). Returns true if `n` reached within that time. Reset with
+  `expect-mock-emails` between tests using the same system."
+    ([]
+     (wait-for-mock-emails 100))
+    ([wait-ms]
+     (.await @email-latch wait-ms TimeUnit/MILLISECONDS)))
 
   (defn mock-mailer []
     (expect-mock-emails)

--- a/src/clojars/repo_indexing.clj
+++ b/src/clojars/repo_indexing.clj
@@ -1,0 +1,107 @@
+(ns clojars.repo-indexing
+  (:require
+   [clojars.s3 :as s3]
+   [clojars.web.common :as common]
+   [clojars.web.safe-hiccup :as safe-hiccup]
+   [clojure.string :as str]
+   [hiccup.element :as el]))
+
+(defn- last-segment
+  [path]
+  (peek (str/split path #"/")))
+
+(defn- entry-line-dispatch
+  [entry]
+  (if (:Prefix entry)
+    :prefix
+    :file))
+
+(defmulti entry-line
+  #'entry-line-dispatch)
+
+(def ^:private name-col-width 50)
+(def ^:private date-col-width 16)
+(def ^:private size-col-width 10)
+
+(defn- blanks
+  [max-len content-str]
+  (apply str (repeat (- max-len (count content-str)) " ")))
+
+(def ^:private dash "-")
+
+(defmethod entry-line :prefix
+  [{:keys [Prefix]}]
+  (let [suffix (format "%s/" (last-segment Prefix))]
+    (list
+     (el/link-to {:title suffix} suffix suffix)
+     (blanks name-col-width suffix)
+     (blanks date-col-width dash)
+     dash
+     (blanks size-col-width dash)
+     dash
+     "\n")))
+
+(defmethod entry-line :file
+  [{:keys [Key LastModified Size]}]
+  (let [file-name (last-segment Key)
+        size (str Size)]
+    (list
+     (el/link-to {:title file-name} file-name file-name)
+     (blanks name-col-width file-name)
+     (common/format-date-with-time LastModified)
+     (blanks size-col-width size)
+     size
+     "\n")))
+
+(defn generate-index
+  [path entries]
+  (safe-hiccup/html5
+   {:lang "en"}
+   [:head
+    [:meta {:charset "utf-8"}]
+    [:meta {:name "viewport" :content "width=device-width,initial-scale=1"}]
+    [:title (format "Clojars Repository: %s" path)]]
+   [:body
+    [:header
+     [:h1 (or path "/")]]
+    [:hr]
+    [:main
+     [:pre#contents
+      (when (some? path)
+        (list
+         (el/link-to "../" "../")
+         "\n"))
+      (mapcat entry-line entries)]]
+    [:hr]]))
+
+(defn- sort-entries
+  [entries]
+  (sort
+   (fn [e1 e2]
+     (cond
+       (and (:Prefix e1) (:Prefix e2)) (compare (:Prefix e1) (:Prefix e2))
+       (:Prefix e1)                    -1
+       (:Prefix e2)                    1
+       :else                           (compare (:Key e1) (:Key e2))))
+   entries))
+
+(defn get-path-entries
+  [repo-bucket path]
+  (->> (s3/list-entries repo-bucket path)
+       ;; filter out index files
+       (remove (fn [{:keys [Key]}]
+                 (and Key
+                      (str/ends-with? Key "index.html"))))
+       (sort-entries)))
+
+(defn normalize-path
+  [path]
+  (let [path (cond
+               (str/blank? path)           nil
+               (= "/" path)                nil
+               (str/starts-with? path "/") (subs path 1)
+               :else                       path)]
+    (if (and (some? path)
+             (not (str/ends-with? path "/")))
+      (str path "/")
+      path)))

--- a/src/clojars/retry.clj
+++ b/src/clojars/retry.clj
@@ -1,0 +1,27 @@
+(ns clojars.retry
+  (:require
+   [clojars.errors :as errors]))
+
+(defn retry*
+  [{:keys [n sleep jitter error-reporter]
+    :or {sleep 1000
+         jitter 20
+         n 3}}
+   f]
+  (loop [i n]
+    (if (> i 0)
+      (let [result (try
+                     (f)
+                     (catch Exception t
+                       t))]
+        (if (instance? Exception result)
+          (do (errors/report-error error-reporter result)
+              (Thread/sleep (+ sleep (rand-int jitter)))
+              (recur (dec i)))
+          result))
+      (throw (ex-info (format "Retry limit %s has been reached" n)
+                      {:n n :sleep sleep :jitter jitter})))))
+
+(defmacro retry
+  [opts & body]
+  `(retry* ~opts (fn [] ~@body)))

--- a/src/clojars/s3.clj
+++ b/src/clojars/s3.clj
@@ -214,6 +214,7 @@
        :clj            :txt
        :eclipse-plugin :zip
        :gz             "application/gzip"
+       :html           "text/html"
        :jar            "application/x-java-archive"
        :md5            :txt
        :pom            :xml

--- a/src/clojars/system.clj
+++ b/src/clojars/system.clj
@@ -12,6 +12,7 @@
    [clojars.oauth.github :as github]
    [clojars.oauth.gitlab :as gitlab]
    [clojars.remote-service :as remote-service]
+   [clojars.repo-indexing :as repo-indexing]
    [clojars.ring-servlet-patch :as patch]
    [clojars.s3 :as s3]
    [clojars.search :as search]
@@ -91,6 +92,7 @@
           :mailer         (simple-mailer (:mail config))
           :notifications  (notifications/notification-component)
           :repo-bucket    (s3/s3-client (get-in config [:s3 :repo-bucket]))
+          :repo-indexer   (repo-indexing/repo-indexing-component)
           :repo-lister    (repo-listing/repo-lister (:cache-path config))
           :storage        (storage-component (:repo config) (:cdn-token config) (:cdn-url config))))
         (component/system-using
@@ -100,6 +102,7 @@
           :event-emitter  [:error-reporter]
           :http           [:app]
           :notifications  [:db :mailer]
+          :repo-indexer   [:error-reporter :repo-bucket]
           :repo-lister    [:repo-bucket]
           :event-receiver [:error-reporter]
           :storage        [:error-reporter :repo-bucket]}))))

--- a/src/clojars/web/repo_listing.clj
+++ b/src/clojars/web/repo_listing.clj
@@ -1,13 +1,10 @@
 (ns clojars.web.repo-listing
   (:require
    [clojars.maven :as maven]
-   [clojars.s3 :as s3]
-   [clojars.web.common :as common]
+   [clojars.repo-indexing :as repo-indexing]
    [clojars.web.safe-hiccup :as safe-hiccup]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
-   [clojure.string :as str]
-   [hiccup.element :as el]
    [ring.util.response :as ring.response])
   (:import
    (java.io
@@ -16,97 +13,6 @@
     Date)))
 
 (set! *warn-on-reflection* true)
-
-(defn- sort-entries
-  [entries]
-  (sort
-   (fn [e1 e2]
-     (cond
-       (and (:Prefix e1) (:Prefix e2)) (compare (:Prefix e1) (:Prefix e2))
-       (:Prefix e1)                    -1
-       (:Prefix e2)                    1
-       :else                           (compare (:Key e1) (:Key e2))))
-   entries))
-
-(defn- last-segment
-  [path]
-  (peek (str/split path #"/")))
-
-(defn- entry-line-dispatch
-  [entry]
-  (if (:Prefix entry)
-    :prefix
-    :file))
-
-(defmulti entry-line
-  #'entry-line-dispatch)
-
-(def ^:private name-col-width 50)
-(def ^:private date-col-width 16)
-(def ^:private size-col-width 10)
-
-(defn- blanks
-  [max-len content-str]
-  (apply str (repeat (- max-len (count content-str)) " ")))
-
-(def ^:private dash "-")
-
-(defmethod entry-line :prefix
-  [{:keys [Prefix]}]
-  (let [suffix (format "%s/" (last-segment Prefix))]
-    (list
-     (el/link-to {:title suffix} suffix suffix)
-     (blanks name-col-width suffix)
-     (blanks date-col-width dash)
-     dash
-     (blanks size-col-width dash)
-     dash
-     "\n")))
-
-(defmethod entry-line :file
-  [{:keys [Key LastModified Size]}]
-  (let [file-name (last-segment Key)
-        size (str Size)]
-    (list
-     (el/link-to {:title file-name} file-name file-name)
-     (blanks name-col-width file-name)
-     (common/format-date-with-time LastModified)
-     (blanks size-col-width size)
-     size
-     "\n")))
-
-(defn- normalize-path
-  [path]
-  (let [path (cond
-               (str/blank? path)           nil
-               (= "/" path)                nil
-               (str/starts-with? path "/") (subs path 1)
-               :else                       path)]
-    (if (and (some? path)
-             (not (str/ends-with? path "/")))
-      (str path "/")
-      path)))
-
-(defn- index
-  [path entries]
-  (safe-hiccup/html5
-   {:lang "en"}
-   [:head
-    [:meta {:charset "utf-8"}]
-    [:meta {:name "viewport" :content "width=device-width,initial-scale=1"}]
-    [:title (format "Clojars Repository: %s" path)]]
-   [:body
-    [:header
-     [:h1 (or path "/")]]
-    [:hr]
-    [:main
-     [:pre#contents
-      (when (some? path)
-        (list
-         (el/link-to "../" "../")
-         "\n"))
-      (mapcat entry-line entries)]]
-    [:hr]]))
 
 (def ^:private max-age 43200) ;; 12 hours
 
@@ -159,8 +65,8 @@
 
 (defn- response
   [repo-bucket path]
-  (if-some [entries (seq (sort-entries (s3/list-entries repo-bucket path)))]
-    (-> (index path entries)
+  (if-some [entries (seq (repo-indexing/get-path-entries repo-bucket path))]
+    (-> (repo-indexing/generate-index path entries)
         (ring.response/response)
         (ring.response/content-type "text/html;charset=utf-8"))
     not-found-response))
@@ -175,7 +81,7 @@
 
 (defn index-for-path
   [{:keys [cache-path repo-bucket]} path]
-  (let [path (normalize-path path)
+  (let [path (repo-indexing/normalize-path path)
         [response age] (or (validate-path path)
                            (get-cached-response cache-path path)
                            (cache-response cache-path path (response repo-bucket path)))]

--- a/test/clojars/integration/repo_indexing_test.clj
+++ b/test/clojars/integration/repo_indexing_test.clj
@@ -1,0 +1,41 @@
+(ns clojars.integration.repo-indexing-test
+  (:refer-clojure :exclude [key])
+  (:require
+   [clojars.event :as event]
+   [clojars.s3 :as s3]
+   [clojars.test-helper :as help]
+   [clojure.java.io :as io]
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [matcher-combinators.test]))
+
+(use-fixtures :each help/run-test-app)
+
+(defn key
+  [path n]
+  (if path
+    (format "%s/%s" path n)
+    n))
+
+(defn write-data
+  [repo-bucket path]
+  (doseq [k ["a.pom" "a.jar"]]
+    (s3/put-object repo-bucket (key path k) (io/input-stream (io/resource "fake.jar")))))
+
+(defn index-key
+  [path]
+  (key path "index.html"))
+
+(deftest index-for-path-should-work-for-valid-paths
+  (let [{:keys [event-emitter repo-bucket]} help/system]
+    (doseq [path [nil "a" "abc/b" "a_b/c-1/1.0.4+Foo"]
+            :let [key (index-key path)]]
+      (testing (format "with path '%s'" path)
+        (write-data repo-bucket path)
+        (event/emit event-emitter :repo-path-needs-index {:path path})
+        (when (is (help/wait-for-s3-key repo-bucket key))
+          (when (is (s3/object-exists? repo-bucket key))
+            (let [index (with-open [is (s3/get-object-stream repo-bucket key)]
+                          (slurp is))]
+              (is (re-find #"a\.pom" index))
+              (is (re-find #"a\.jar" index))
+              (is (not (re-find #"index\.html" index))))))))))

--- a/test/clojars/integration/users_test.clj
+++ b/test/clojars/integration/users_test.clj
@@ -357,6 +357,11 @@
       (register-as "dantheman" "test@example.org" "password")
       (visit "/groups/org.clojars.dantheman")
       (fill-in [:#username] "fixture")
+      ((fn [session]
+         ;; clear the add emails
+         (email/expect-mock-emails 2)
+         (email/wait-for-mock-emails 1000)
+         session))
       (press "Add Member")
       ((fn [session] (email/expect-mock-emails 2) session))
       (press "Remove Member"))

--- a/test/clojars/test_helper.clj
+++ b/test/clojars/test_helper.clj
@@ -197,3 +197,14 @@
   `(with-redefs [shell/sh (constantly {:out  (TXT-vec->str ~txt-records)
                                        :exit 0})]
      ~@body))
+
+(defn wait-for-s3-key
+  [bucket key]
+  (loop [attempt 0]
+    (if (s3/object-exists? bucket key)
+      true
+      (if (< attempt 10)
+        (do
+          (Thread/sleep 1000)
+          (recur (inc attempt)))
+        false))))


### PR DESCRIPTION
### Extract repo index gen to own ns

This will allow us to use it from the async pre-compute logic.

### Extract retry logic to ns & improve ergonomics

### Generate repo index files on deploy

This will asynchronously generate repo index files for each level when a
deploy occurs and write the index to s3 to be read by fastly.