### PR TITLE
Require licenses for new projects

### DIFF
--- a/dev-resources/test-0.0.1/test-no-license.pom
+++ b/dev-resources/test-0.0.1/test-no-license.pom
@@ -10,13 +10,6 @@
   <name>asdf</name>
   <url>https://example.org</url>
 
-  <licenses>
-    <license>
-      <name>Apache-2.0</name>
-      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-    </license>
-  </licenses>
-
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/dev-resources/test-0.0.3-SNAPSHOT/test.pom
+++ b/dev-resources/test-0.0.3-SNAPSHOT/test.pom
@@ -11,6 +11,13 @@
   <description>TEST</description>
   <url>http://example.com</url>
 
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/resources/queries/queryfile.sql
+++ b/resources/queries/queryfile.sql
@@ -332,6 +332,18 @@ WHERE (
 ORDER BY created DESC
 LIMIT 1;
 
+--name: find-latest-release
+SELECT *
+FROM jars
+WHERE (
+  group_name = :groupname
+  AND
+  jar_name = :jarname
+)
+ORDER BY created DESC
+LIMIT 1;
+
+
 --name: max-jars-id
 SELECT max(id) AS max_id FROM jars;
 

--- a/src/clojars/db.clj
+++ b/src/clojars/db.clj
@@ -316,7 +316,15 @@
                                :result-set-fn first}))))
   (defn all-jars [db]
     (map read-edn-fields
-         (sql/all-jars {} {:connection db}))))
+         (sql/all-jars {} {:connection db})))
+
+  (defn find-latest-release
+    [db groupname jarname]
+    (read-edn-fields
+     (sql/find-latest-release {:groupname groupname
+                               :jarname   jarname}
+                              {:connection    db
+                               :result-set-fn first}))))
 
 (defn find-dependencies
   [db groupname jarname version]

--- a/test/clojars/test_helper.clj
+++ b/test/clojars/test_helper.clj
@@ -151,14 +151,12 @@
 (defn rewrite-pom [file m]
   (let [new-pom (doto (File/createTempFile (.getName file) ".pom")
                   .deleteOnExit)]
-    (-> file
-        slurp
-        (as-> % (reduce (fn [accum [element new-value]]
-                          (str/replace accum (re-pattern (format "<(%s)>.*?<" (name element)))
-                                       (format "<$1>%s<" new-value)))
-                        %
-                        m))
-        (->> (spit new-pom)))
+    (spit new-pom
+          (reduce (fn [accum [element new-value]]
+                    (str/replace accum (re-pattern (format "<(%s)>.*?<" (name element)))
+                                 (format "<$1>%s<" new-value)))
+                  (slurp file)
+                  m))
     new-pom))
 
 (defn at-as-time-str


### PR DESCRIPTION
This will require that any project that is new to have a license in the pom for every released version.

This allows existing projects (ones that had a version released before the boundary date) to continue to deploy versions without licenses, but only if the most recent release did not have a license. If the project has a license, it must continue to provide one. We will remove that in the future after giving ample notice, at which point every deploy must have a license.

This implements #873.