### PR TITLE
Always require license in POM

### DIFF
--- a/src/clojars/db.clj
+++ b/src/clojars/db.clj
@@ -599,20 +599,7 @@
     (map read-edn-fields
          (q db {:select   :*
                 :from     :jars
-                :order-by :id})))
-
-  (defn find-latest-release
-    [db groupname jarname]
-    (-> (q db
-           {:select :*
-            :from :jars
-            :where [:and
-                    [:= :group_name groupname]
-                    [:= :jar_name jarname]]
-            :order-by [[:created :desc]]
-            :limit 1})
-        (first)
-        (read-edn-fields))))
+                :order-by :id}))))
 
 (defn find-dependencies
   [db groupname jarname version]

--- a/src/clojars/routes/repo.clj
+++ b/src/clojars/routes/repo.clj
@@ -215,23 +215,17 @@
      {:pom pom-data})))
 
 (defn- validate-pom-license
-  [db pom group name]
+  [pom]
   (when (empty? (:licenses pom))
-    (let [latest-release (db/find-latest-release db group name)]
-      ;; Require a license if:
-      ;; - this is a new project
-      ;; - the prior released version had a license
-      (when (or (not latest-release)
-                (seq (:licenses latest-release)))
-        (throw-invalid
-         :missing-license
-         "the POM file does not include a license. See https://bit.ly/3PQunZU")))))
+    (throw-invalid
+     :missing-license
+     "the POM file does not include a license. See https://bit.ly/3PQunZU")))
 
-(defn- validate-pom [db pom group name version]
+(defn- validate-pom [pom group name version]
   (validate-pom-entry pom :group group)
   (validate-pom-entry pom :name name)
   (validate-pom-entry pom :version version)
-  (validate-pom-license db pom group name))
+  (validate-pom-license pom))
 
 (defn- validate-module-entry
   "Validates a key in a Gradle module"
@@ -323,7 +317,7 @@
   (validate-jar-name+version name version)
   (when module
     (validate-module module group name version))
-  (validate-pom db pom group name version)
+  (validate-pom pom group name version)
   (assert-non-redeploy db group name version)
   (assert-non-central-shadow group name)
 

--- a/test/clojars/integration/uploads_test.clj
+++ b/test/clojars/integration/uploads_test.clj
@@ -10,7 +10,6 @@
    [clojars.file-utils :as fu]
    [clojars.http-utils :refer [clear-sessions!]]
    [clojars.integration.steps :refer [create-deploy-token login-as register-as]]
-   [clojars.routes.repo :as repo]
    [clojars.s3 :as s3]
    [clojars.test-helper :as help]
    [clojars.web.common :as common]
@@ -624,7 +623,7 @@
   ;; This test throws on failure, so we have this assertion to satisfy kaocha
   (is true))
 
-(deftest new-project-must-include-license
+(deftest release-must-include-license
   (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password"))
   (let [token (create-deploy-token (session (help/app)) "dantheman" "password" "testing")]
@@ -644,65 +643,6 @@
                        :version "0.0.1"
                        :message "the POM file does not include a license. See https://bit.ly/3PQunZU"
                        :tag "missing-license"})))
-
-(deftest existing-project-with-no-license-does-not-require-license
-  (-> (session (help/app))
-      (register-as "dantheman" "test@example.org" "password"))
-  (let [token (create-deploy-token (session (help/app)) "dantheman" "password" "testing")]
-    ;; Deploy a version with no license with license check disabled so we can
-    ;; get this project in a legacy state
-    (with-redefs [repo/validate-pom-license (constantly true)]
-      (deploy
-       {:coordinates '[org.clojars.dantheman/test "0.0.1"]
-        :jar-file (io/file (io/resource "test.jar"))
-        :pom-file (io/file (io/resource "test-0.0.1/test-no-license.pom"))
-        :password token}))
-
-    ;; Deploy a new version that doesn't have a license
-    (deploy
-     {:coordinates '[org.clojars.dantheman/test "0.0.2"]
-      :jar-file (io/file (io/resource "test.jar"))
-      :pom-file (help/rewrite-pom (io/file (io/resource "test-0.0.1/test-no-license.pom"))
-                                  {:version "0.0.2"})
-      :password token})
-
-    (help/match-audit {:username "dantheman"}
-                      {:user "dantheman"
-                       :group_name "org.clojars.dantheman"
-                       :jar_name "test"
-                       :version "0.0.2"
-                       :tag "deployed"})))
-
-(deftest project-that-had-license-for-most-recent-release-must-provide-license
-  (-> (session (help/app))
-      (register-as "dantheman" "test@example.org" "password"))
-  (let [token (create-deploy-token (session (help/app)) "dantheman" "password" "testing")]
-    ;; Deploy a version with a license
-    (deploy
-     {:coordinates '[org.clojars.dantheman/test "0.0.1"]
-      :jar-file (io/file (io/resource "test.jar"))
-      :pom-file (io/file (io/resource "test-0.0.1/test.pom"))
-      :password token})
-
-    ;; Deploy a new version that doesn't have a license
-    (is (thrown-with-msg?
-         DeploymentException
-         #"Forbidden - the POM file does not include a license"
-          (deploy
-           {:coordinates '[org.clojars.dantheman/test "0.0.2"]
-            :jar-file (io/file (io/resource "test.jar"))
-            :pom-file (help/rewrite-pom (io/file (io/resource "test-0.0.1/test-no-license.pom"))
-                                        {:version "0.0.2"})
-            :password token})))
-
-    (help/match-audit {:username "dantheman"}
-                      {:user "dantheman"
-                       :group_name "org.clojars.dantheman"
-                       :jar_name "test"
-                       :version "0.0.2"
-                       :message "the POM file does not include a license. See https://bit.ly/3PQunZU"
-                       :tag "missing-license"})))
-
 
 (deftest user-can-deploy-new-version-in-same-session
   (-> (session (help/app))


### PR DESCRIPTION
This removes the interim setup that allows projects that don't have a license to continue to deploy without one.

Completes #873.

**Do not merge until 2024-01-01.**