### PR TITLE
Project-level deploy scoping

### DIFF
--- a/resources/public/js/permissions.js
+++ b/resources/public/js/permissions.js
@@ -1,0 +1,14 @@
+const showHideNewJarInput = () => {
+  const tb = $('#scope_to_jar_new');
+  if ($('#scope_to_jar_select option:checked').val() === ':new') {
+    tb.show();
+  } else {
+    tb.hide();
+    tb.val('');
+  }
+};
+
+$(() => {
+  $('#scope_to_jar_select').on('change', showHideNewJarInput);
+  showHideNewJarInput();
+});

--- a/src/clojars/auth.clj
+++ b/src/clojars/auth.clj
@@ -20,22 +20,18 @@
 (defn with-account [f]
   (friend/authenticated (try-account f)))
 
-(defn authorized-admin? [db account group]
+(defn authorized-admin? [db account group scope]
   (when account
-    (let [adminnames (db/group-adminnames db group)
+    (let [adminnames (db/group-adminnames db group scope)
           allnames (db/group-allnames db group)]
       (or (some #{account} adminnames) (empty? allnames)))))
-
-(defn authorized-member? [db account group]
-  (when account
-    (some #{account} (db/group-membernames db group))))
 
 (defn authorized-group-access? [db account group]
   (when account
     (some #{account} (db/group-allnames db group))))
 
-(defn require-admin-authorization [db account group f]
-  (if (authorized-admin? db account group)
+(defn require-admin-authorization [db account group scope f]
+  (if (authorized-admin? db account group scope)
     (f)
     (friend/throw-unauthorized friend/*identity*
                                {:cemerick.friend/required-roles group})))

--- a/src/clojars/db/migrate.clj
+++ b/src/clojars/db/migrate.clj
@@ -126,6 +126,13 @@
    ["alter table groups rename to permissions"
     "alter table permissions rename column name to group_name"]))
 
+(defn- add-scope-to-permissions
+  [tx]
+  (db/do-commands
+   tx
+   ["alter table permissions add scope text default '*' not null"
+    "create index permissions_idx0 on permissions (group_name, scope)"]))
+
 (def migrations
   [#'initial-schema
    #'add-deploy-tokens-table
@@ -140,7 +147,8 @@
    #'add-send-deploy-emails-to-users
    #'add-indexes-to-deps-table
    #'add-group-settings-table
-   #'rename-groups-to-permissions])
+   #'rename-groups-to-permissions
+   #'add-scope-to-permissions])
 
 (defn migrate [db]
   (db/do-commands db

--- a/src/clojars/db/migrate.clj
+++ b/src/clojars/db/migrate.clj
@@ -9,7 +9,7 @@
    (java.io
     File)))
 
-(defn initial-schema [trans]
+(defn initial-schema [tx]
   (doseq [cmd (map str/trim
                    (-> (str "queries" (File/separator) "clojars.sql")
                        io/resource
@@ -17,21 +17,21 @@
                        (str/split #";\s*")))
           :when (not (.isEmpty cmd))
           :when (not (re-find #"^\s*--" cmd))]
-    (db/do-commands trans [cmd])))
+    (db/do-commands tx [cmd])))
 
 ;; migrations mechanics
 
-(defn run-and-record [migration trans]
+(defn run-and-record [migration tx]
   (println "Running migration:" (:name (meta migration)))
-  (migration trans)
-  (sql/insert! trans
+  (migration tx)
+  (sql/insert! tx
                :migrations
                {:name       (-> migration (meta) :name (str))
                 :created_at (db/get-time)}))
 
 (defn- add-deploy-tokens-table
-  [trans]
-  (db/do-commands trans
+  [tx]
+  (db/do-commands tx
                   [(str "create table deploy_tokens "
                         "(id serial not null primary key,"
                         " user_id integer not null references users(id) on delete cascade,"
@@ -42,35 +42,35 @@
                         " disabled boolean not null default false)")]))
 
 (defn- add-last-used-to-deploy-tokens-table
-  [trans]
-  (db/do-commands trans
+  [tx]
+  (db/do-commands tx
                   [(str "alter table deploy_tokens "
                         "add last_used timestamp default null")]))
 
 (defn- add-group-and-jar-to-deploy-tokens-table
-  [trans]
-  (db/do-commands trans
+  [tx]
+  (db/do-commands tx
                   [(str "alter table deploy_tokens "
                         "add group_name text default null,"
                         "add jar_name text default null")]))
 
 (defn- add-mfa-fields-to-users-table
-  [trans]
-  (db/do-commands trans
+  [tx]
+  (db/do-commands tx
                   [(str "alter table users "
                         "add otp_secret_key text default null,"
                         "add otp_recovery_code text default null,"
                         "add otp_active boolean default false")]))
 
 (defn- add-hash-to-deploy-tokens-table
-  [trans]
-  (db/do-commands trans
+  [tx]
+  (db/do-commands tx
                   [(str "alter table deploy_tokens "
                         "add token_hash text default null")]))
 
 (defn- add-group-verifications-table
-  [trans]
-  (db/do-commands trans
+  [tx]
+  (db/do-commands tx
                   [(str "create table group_verifications "
                         "(id serial not null primary key,"
                         "group_name text unique not null,"
@@ -78,8 +78,8 @@
                         "created timestamp not null default current_timestamp)")]))
 
 (defn- add-audit-table
-  [trans]
-  (db/do-commands trans
+  [tx]
+  (db/do-commands tx
                   [(str "create table audit "
                         "(\"user\" text,"
                         "group_name text,"
@@ -90,34 +90,41 @@
                         "created timestamp not null default current_timestamp)")]))
 
 (defn- add-single-use-to-tokens
-  [trans]
-  (db/do-commands trans
+  [tx]
+  (db/do-commands tx
                   ["create type single_use_status as enum ('no', 'yes', 'used')"
                    "alter table deploy_tokens add single_use single_use_status default 'no'"]))
 
 (defn- add-expires-at-to-tokens
-  [trans]
-  (db/do-commands trans
+  [tx]
+  (db/do-commands tx
                   ["alter table deploy_tokens add expires_at timestamp"]))
 
 (defn- add-send-deploy-emails-to-users
-  [trans]
-  (db/do-commands trans
+  [tx]
+  (db/do-commands tx
                   ["alter table users add send_deploy_emails boolean default false"]))
 
 (defn- add-indexes-to-deps-table
-  [trans]
-  (db/do-commands trans
+  [tx]
+  (db/do-commands tx
                   ["create index deps_idx0 on deps (dep_group_name, dep_jar_name)"
                    "create index deps_idx1 on deps (group_name, jar_name, version)"]))
 
 (defn- add-group-settings-table
-  [trans]
-  (db/do-commands trans
+  [tx]
+  (db/do-commands tx
                   [(str "create table group_settings "
                         "(group_name text primary key,"
                         "require_mfa_to_deploy bool,"
                         "updated timestamp not null default current_timestamp)")]))
+
+(defn- rename-groups-to-permissions
+  [tx]
+  (db/do-commands
+   tx
+   ["alter table groups rename to permissions"
+    "alter table permissions rename column name to group_name"]))
 
 (def migrations
   [#'initial-schema
@@ -132,17 +139,18 @@
    #'add-expires-at-to-tokens
    #'add-send-deploy-emails-to-users
    #'add-indexes-to-deps-table
-   #'add-group-settings-table])
+   #'add-group-settings-table
+   #'rename-groups-to-permissions])
 
 (defn migrate [db]
   (db/do-commands db
                   [(str "create table if not exists migrations "
                         "(name varchar not null, "
                         "created_at timestamp not null default current_timestamp)")])
-  (jdbc/with-transaction [trans db]
+  (jdbc/with-transaction [tx db]
     (let [has-run? (into #{}
                          (map :migrations/name)
-                         (sql/query trans ["SELECT name FROM migrations"]))]
+                         (sql/query tx ["SELECT name FROM migrations"]))]
       (doseq [m migrations
               :when (not (has-run? (str (:name (meta m)))))]
-        (run-and-record m trans)))))
+        (run-and-record m tx)))))

--- a/src/clojars/dev/setup.clj
+++ b/src/clojars/dev/setup.clj
@@ -21,7 +21,7 @@
     (db/do-commands
      db
      ["delete from deps"
-      "delete from groups"
+      "delete from permissions"
       "delete from jars"
       "delete from users"
       "delete from group_verifications"

--- a/src/clojars/dev/setup.clj
+++ b/src/clojars/dev/setup.clj
@@ -89,7 +89,8 @@
                  [_ group-path artifact-id] (re-find group-artifact-pattern (get-path parent))
                  version (.getName version-dir)
                  group-id (str/lower-case (fu/path->group group-path))
-                 user (or (first (db/group-adminnames db group-id)) (rand-nth users))]]
+                 user (or (first (db/group-adminnames db group-id db/SCOPE-ALL))
+                          (rand-nth users))]]
        (when-not (db/find-jar db group-id artifact-id version)
          (printf "Importing %s/%s %s (user: %s)\n" group-id artifact-id version user)
          (db/add-group db user group-id)

--- a/src/clojars/email.clj
+++ b/src/clojars/email.clj
@@ -53,12 +53,12 @@
      (reset! email-latch (CountDownLatch. n))))
 
   (defn wait-for-mock-emails
-    "Blocks for up to `wait-ms` (default: 100ms) waiting for `n` emails to be sent
+    "Blocks for up to `wait-ms` (default: 1000ms) waiting for `n` emails to be sent
   via the mock, where `n` was passed to `expect-mock-emails` (defaulting to 1 if
   not called). Returns true if `n` reached within that time. Reset with
   `expect-mock-emails` between tests using the same system."
     ([]
-     (wait-for-mock-emails 100))
+     (wait-for-mock-emails 1000))
     ([wait-ms]
      (.await @email-latch wait-ms TimeUnit/MILLISECONDS)))
 

--- a/src/clojars/notifications/group.clj
+++ b/src/clojars/notifications/group.clj
@@ -3,34 +3,40 @@
    [clojars.notifications :as notifications]
    [clojars.notifications.common :as common]))
 
-(defmethod notifications/notification :group-member-added
+(defmethod notifications/notification :group-permission-added
   [_type mailer
    {:as _user username :user}
-   {:as data :keys [admin? group member admin-emails member-email]}]
-  (let [subject (format "A%s member was added to the group %s"
+   {:as data :keys [admin? group member admin-emails member-email scope-to-jar]}]
+  (let [subject (format "A%s permission was added to the group %s"
                         (if admin? "n admin" "")
                         group)
         body [(format
-               "User '%s' was added%s to the %s group by %s."
+               "User '%s' was added%s to the %s group with scope %s by %s."
                member
                (if admin? " as an admin" "")
                group
+               (if (nil? scope-to-jar)
+                 ":all-jars"
+                 (format "'%s'" scope-to-jar))
                username)
               (common/details-table data)]
         emails (set (concat admin-emails [member-email]))]
     (doseq [email emails]
       (notifications/send mailer email subject body))))
 
-(defmethod notifications/notification :group-member-removed
+(defmethod notifications/notification :group-permission-removed
   [_type mailer
    {:as _user username :user}
-   {:as data :keys [group member admin-emails member-email]}]
-  (let [subject (format "A member was removed from the group %s"
+   {:as data :keys [group member admin-emails member-email scope-to-jar]}]
+  (let [subject (format "A permission was removed from the group %s"
                         group)
         body [(format
-               "User '%s' was removed from the %s group by %s."
+               "User '%s' was removed from the %s group with scope %s by %s."
                member
                group
+               (if (nil? scope-to-jar)
+                 ":all-jars"
+                 (format "'%s'" scope-to-jar))
                username)
               (common/details-table data)]
         emails (set (concat admin-emails [member-email]))]

--- a/src/clojars/routes/repo.clj
+++ b/src/clojars/routes/repo.clj
@@ -143,9 +143,9 @@
       (ex-data e-or-message))
      cause)))
 
-(defn- check-group [db account group artifact]
+(defn- check-group+project [db account group artifact]
   (try
-    (db/check-group db account group artifact)
+    (db/check-group+project db account group artifact)
     (catch Exception e
       (throw-forbidden e
                        {:account account
@@ -162,7 +162,7 @@
                          :username account}
         (when artifact
           ;; will throw if there are any issues
-          (check-group db account groupname artifact))
+          (check-group+project db account groupname artifact))
         (let [upload-dir (find-upload-dir groupname artifact version timestamp-version session)]
           (f account upload-dir)
           ;; should we only do 201 if the file didn't already exist?
@@ -502,7 +502,7 @@
            ;; but since this includes the group authorization check,
            ;; we do it here just in case. Will throw if there are any
            ;; issues.
-           (check-group db account groupname artifact)
+           (check-group+project db account groupname artifact)
            (deploy-post-finalized-file storage upload-dir file)))))))
 
 ;; web handlers

--- a/src/clojars/web/dashboard.clj
+++ b/src/clojars/web/dashboard.clj
@@ -110,5 +110,6 @@
        [:li (link-to "https://github.com/clojars/clojars-web/wiki/Pushing" "How do I deploy to clojars?")]
        [:li (link-to "https://github.com/clojars/clojars-web/wiki/Data" "How can I access clojars data programatically?")]
        [:li (link-to "https://github.com/clojars/clojars-web/wiki/Groups" "What are groups?")]
-       [:li (link-to "https://github.com/clojars/clojars-web/wiki/POM" "What does my POM need to look like?")]]]]]
+       [:li (link-to "https://github.com/clojars/clojars-web/wiki/Verified-Group-Names" "How do I verify a group name?")]
+       [:li (link-to "https://github.com/clojars/clojars-web/wiki/" "More...")]]]]]
    (audit-table db account {:username account})))

--- a/src/clojars/web/group.clj
+++ b/src/clojars/web/group.clj
@@ -61,36 +61,48 @@
       (unordered-list (map jar-link all-group-jars))
       [:h2 "Permissions"]
       (if show-membership-details?
-        [:table.group-member-list
-         [:thead
-          [:tr
-           [:th "Username"]
-           [:th "Scope"]
-           [:th "Admin?"]]]
-         [:tbody
-          (for [active (sort-by :user actives)
-                :let [{:keys [admin scope user]} active]]
-            [:tr
-             [:td (user-link user)]
-             [:td scope]
-             [:td
-              (if admin "Yes" "No")]
-             (when (and (not= account user)
-                        (current-user-admin-for-scope? scope))
-               (list
-                [:td
-                 (form-to [:post (str "/groups/" groupname)]
-                          (hidden-field "username" user)
-                          (hidden-field "scope_to_jar" scope)
-                          (hidden-field "admin" (if admin 0 1))
-                          [:input.button.green-button {:type "submit"
-                                                       :value "Toggle Admin"}])]
-                [:td
-                 (form-to [:delete (str "/groups/" groupname)]
-                          (hidden-field "username" user)
-                          (hidden-field "scope_to_jar" scope)
-                          [:input.button.red-button {:type "submit"
-                                                     :value "Remove Permission"}])]))])]]
+        (list
+         [:details.help
+          [:summary "Help"]
+          [:p "A user that has a permission in a group can deploy new versions
+           of projects that are within the group. Users scoped to All
+           Projects (*) can deploy any existing project within the group, and
+           can deploy new projects. A user scoped to one or more projects can
+           only deploy to those projects."]
+          [:p "An Admin permission for a given project scope will allow the
+           user (in addition to the right to deploy) to add permissions, but
+           only within that scope. For example, an Admin user scoped to the
+           'foo' project can only add new permissions scoped to 'foo'."]]
+         [:table.group-member-list
+          [:thead
+           [:tr
+            [:th "Username"]
+            [:th "Scope"]
+            [:th "Admin?"]]]
+          [:tbody
+           (for [active (sort-by :user actives)
+                 :let [{:keys [admin scope user]} active]]
+             [:tr
+              [:td (user-link user)]
+              [:td scope]
+              [:td
+               (if admin "Yes" "No")]
+              (when (and (not= account user)
+                         (current-user-admin-for-scope? scope))
+                (list
+                 [:td
+                  (form-to [:post (str "/groups/" groupname)]
+                           (hidden-field "username" user)
+                           (hidden-field "scope_to_jar" scope)
+                           (hidden-field "admin" (if admin 0 1))
+                           [:input.button.green-button {:type "submit"
+                                                        :value "Toggle Admin"}])]
+                 [:td
+                  (form-to [:delete (str "/groups/" groupname)]
+                           (hidden-field "username" user)
+                           (hidden-field "scope_to_jar" scope)
+                           [:input.button.red-button {:type "submit"
+                                                      :value "Remove Permission"}])]))])]])
         (unordered-list (->> (db/group-all-actives db groupname)
                              (into []
                                    (comp
@@ -113,7 +125,7 @@
                       :id "admin"
                       :value 1
                       :checked false}]]
-            [[:label "Limit access to project "]
+            [[:label "Scope to project "]
              [:span
               [:select
                {:name :scope_to_jar

--- a/src/clojars/web/group.clj
+++ b/src/clojars/web/group.clj
@@ -1,94 +1,140 @@
 (ns clojars.web.group
   (:require
-   [clojars.auth :refer [authorized-admin? authorized-member?]]
-   [clojars.db :refer [find-group-verification get-group-settings jars-by-groupname]]
+   [clojars.db :as db]
    [clojars.web.common :refer [audit-table form-table html-doc jar-link user-link error-list verified-group-badge-small]]
    [clojars.web.safe-hiccup :refer [form-to]]
    [clojars.web.structured-data :as structured-data]
    [hiccup.element :refer [unordered-list]]
-   [hiccup.form :refer [text-field hidden-field]]))
+   [hiccup.form :refer [text-field hidden-field select-options]]))
 
-(def is-admin? :admin)
+(defn- scope-options
+  [db account groupname actives all-group-jars]
+  (let [admin-scopes-for-user (db/admin-group-scopes-for-user db account groupname)
+        admin-all? (contains? admin-scopes-for-user db/SCOPE-ALL)
+        all-visible-jar-scopes (into #{}
+                                     (comp
+                                      (filter #(or
+                                                admin-all?
+                                                (contains? admin-scopes-for-user %)))
+                                      (remove #(= db/SCOPE-ALL %)))
+                                     (concat
+                                      (map :jar_name all-group-jars)
+                                      (map :scope actives)))]
+    (into (if admin-all?
+            [["All Projects"   "*"]
+             ["New Project..." ":new"]]
+            [])
+          (map #(vector % %))
+          all-visible-jar-scopes)))
 
-(defn show-group [db account groupname actives & errors]
-  (let [admin? (authorized-admin? db account groupname)
-        member? (authorized-member? db account groupname)
-        show-membership-details? (or admin? member?)
-        verified-group? (find-group-verification db groupname)
-        group-settings (get-group-settings db groupname)]
-    (html-doc (str groupname " group") {:account account :description (format "Clojars projects in the %s group" groupname)}
-              [:div.col-xs-12
-               (structured-data/breadcrumbs [{:url  (str "https://clojars.org/groups/" groupname)
-                                              :name groupname}])
-               [:div#group-title
-                [:h1 (str groupname " group")]
-                (when (and verified-group? show-membership-details?)
-                  verified-group-badge-small)]
-               [:h2 "Projects"]
-               (unordered-list (map jar-link (jars-by-groupname db groupname)))
-               [:h2 "Members"]
-               (if show-membership-details?
-                 [:table.group-member-list
-                  [:thead
-                   [:tr
-                    [:th "Username"]
-                    [:th "Admin?"]]]
-                  [:tbody
-                   (for [active (sort-by :user actives)]
-                     [:tr
-                      [:td (user-link (:user active))]
-                      [:td
-                       (if (is-admin? active)
-                         "Yes"
-                         "No")]
-                      (when admin?
-                        (list
-                         [:td
-                          (cond
-                            (= account (:user active)) ""
-                            (is-admin? active)
-                            (form-to [:post (str "/groups/" groupname)]
-                                     (hidden-field "username" (:user active))
-                                     (hidden-field "admin" 0)
-                                     [:input.button {:type "submit" :value "Toggle Admin"}])
-                            :else
-                            (form-to [:post (str "/groups/" groupname)]
-                                     (hidden-field "username" (:user active))
-                                     (hidden-field "admin" 1)
-                                     [:input.button.green-button {:type "submit" :value "Toggle Admin"}]))]
-                         [:td
-                          (if (= account (:user active))
-                            ""
-                            (form-to [:delete (str "/groups/" groupname)]
-                                     (hidden-field "username" (:user active))
-                                     [:input.button.red-button {:type "submit" :value "Remove Member"}]))]))])]]
-                 (unordered-list (map user-link (sort (map :user actives)))))
-               (error-list errors)
-               (when admin?
-                 (list
-                  [:div.add-member
-                   [:h2 "Add member to group"]
-                   (form-table
-                    [:post (str "/groups/" groupname)]
-                    [[[:label "Username "]
-                      (text-field "username")]
-                     [[:label "Admin? "]
-                      [:input {:type "checkbox"
-                               :name "admin"
-                               :id "admin"
-                               :value 1
-                               :checked false}]]]
-                    [:input.button {:type "submit" :value "Add Member"}])]
-                  [:div.group-settings
-                   [:h2 "Group Settings"]
-                   (form-table
-                    [:post (format "/groups/%s/settings" groupname)]
-                    [[[:label "Require users to have two-factor auth enabled to deploy? "]
-                      [:input {:type "checkbox"
-                               :name "require_mfa"
-                               :id "require_mfa"
-                               :value 1
-                               :checked (:require_mfa_to_deploy group-settings false)}]]]
-                    [:input.button {:type "submit" :value "Update Settings"}])]))
-               (when show-membership-details?
-                 (audit-table db groupname {:group-name groupname}))])))
+(defn show-group
+  [db account groupname & errors]
+  (let [actives (db/group-actives db groupname)
+        actives-for-user (db/group-actives-for-user db groupname account)
+        user-admin-scopes (into #{}
+                                (comp
+                                 (filter #(= account (:user %)))
+                                 (filter :admin)
+                                 (map :scope))
+                                actives-for-user)
+        current-user-admin? (seq user-admin-scopes)
+        current-user-admin-for-scope? (fn [scope]
+                                        (or (contains? user-admin-scopes db/SCOPE-ALL)
+                                            (contains? user-admin-scopes scope)))
+        show-membership-details? (seq actives-for-user)
+        verified-group? (db/find-group-verification db groupname)
+        group-settings (db/get-group-settings db groupname)
+        all-group-jars (db/jars-by-groupname db groupname)]
+    (html-doc
+     (str groupname " group")
+     {:account account
+      :description (format "Clojars projects in the %s group" groupname)
+      :extra-js ["/js/permissions.js"]}
+     [:div.col-xs-12
+      (structured-data/breadcrumbs [{:url  (str "https://clojars.org/groups/" groupname)
+                                     :name groupname}])
+      [:div#group-title
+       [:h1 (str groupname " group")]
+       (when (and verified-group? show-membership-details?)
+         verified-group-badge-small)]
+      [:h2 "Projects"]
+      (unordered-list (map jar-link all-group-jars))
+      [:h2 "Permissions"]
+      (if show-membership-details?
+        [:table.group-member-list
+         [:thead
+          [:tr
+           [:th "Username"]
+           [:th "Scope"]
+           [:th "Admin?"]]]
+         [:tbody
+          (for [active (sort-by :user actives)
+                :let [{:keys [admin scope user]} active]]
+            [:tr
+             [:td (user-link user)]
+             [:td scope]
+             [:td
+              (if admin "Yes" "No")]
+             (when (and (not= account user)
+                        (current-user-admin-for-scope? scope))
+               (list
+                [:td
+                 (form-to [:post (str "/groups/" groupname)]
+                          (hidden-field "username" user)
+                          (hidden-field "scope_to_jar" scope)
+                          (hidden-field "admin" (if admin 0 1))
+                          [:input.button.green-button {:type "submit"
+                                                       :value "Toggle Admin"}])]
+                [:td
+                 (form-to [:delete (str "/groups/" groupname)]
+                          (hidden-field "username" user)
+                          (hidden-field "scope_to_jar" scope)
+                          [:input.button.red-button {:type "submit"
+                                                     :value "Remove Permission"}])]))])]]
+        (unordered-list (->> (db/group-all-actives db groupname)
+                             (into []
+                                   (comp
+                                    (map :user)
+                                    (distinct)))
+                             (sort)
+                             (mapv user-link))))
+      (error-list errors)
+      (when current-user-admin?
+        (list
+         [:div.add-member
+          [:h2 "Add permission to group"]
+          (form-table
+           [:post (str "/groups/" groupname)]
+           [[[:label "Username "]
+             (text-field "username")]
+            [[:label "Admin? "]
+             [:input {:type "checkbox"
+                      :name "admin"
+                      :id "admin"
+                      :value 1
+                      :checked false}]]
+            [[:label "Limit access to project "]
+             [:span
+              [:select
+               {:name :scope_to_jar
+                :id :scope_to_jar_select}
+               (select-options (scope-options db account groupname actives all-group-jars))]
+              " "
+              (text-field {:placeholder "new project"}
+                          :scope_to_jar_new)]]]
+           [:input.button {:type "submit" :value "Add Permission"}])]
+         ;; Only all-scoped admins can change group-wide settings
+         (when (current-user-admin-for-scope? db/SCOPE-ALL)
+           [:div.group-settings
+            [:h2 "Group Settings"]
+            (form-table
+             [:post (format "/groups/%s/settings" groupname)]
+             [[[:label "Require users to have two-factor auth enabled to deploy? "]
+               [:input {:type "checkbox"
+                        :name "require_mfa"
+                        :id "require_mfa"
+                        :value 1
+                        :checked (:require_mfa_to_deploy group-settings false)}]]]
+             [:input.button {:type "submit" :value "Update Settings"}])])))
+      (when show-membership-details?
+        (audit-table db groupname {:group-name groupname}))])))

--- a/test/clojars/integration/group_permissions_test.clj
+++ b/test/clojars/integration/group_permissions_test.clj
@@ -1,0 +1,556 @@
+(ns clojars.integration.group-permissions-test
+  (:require
+   [clojars.db :as db]
+   [clojars.email :as email]
+   [clojars.integration.steps :refer [login-as register-as]]
+   ;; for defmethods
+   [clojars.notifications.group]
+   [clojars.test-helper :as help]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [kerodon.core :refer [check choose fill-in press session visit within]]
+   [kerodon.test :refer [has text?]]
+   [net.cgrand.enlive-html :as enlive]
+   [peridot.core :as p]))
+
+(use-fixtures :each
+  help/default-fixture
+  help/with-clean-database
+  help/run-test-app)
+
+(deftest admin-can-add-member-to-group
+  (-> (session (help/app))
+      (register-as "fixture" "fixture@example.org" "password"))
+  (-> (session (help/app))
+      (register-as "dantheman" "test@example.org" "password")
+      ((fn [session] (email/expect-mock-emails 2) session))
+      (visit "/groups/org.clojars.dantheman")
+      (fill-in [:#username] "fixture")
+      (press "Add Permission")
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td enlive/first-of-type]]
+        (has (text? "fixture")))
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td (enlive/nth-of-type 2)]]
+        (has (text? "*")))
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td (enlive/nth-of-type 3)]]
+        (has (text? "No"))))
+
+  (is (some #{"fixture"} (db/group-membernames help/*db* "org.clojars.dantheman" db/SCOPE-ALL)))
+
+  (help/match-audit {:username "dantheman"}
+                    {:tag "permission-added"
+                     :user "dantheman"
+                     :group_name "org.clojars.dantheman"
+                     :message "user 'fixture' added as member with '*' scope"})
+
+  (is (true? (email/wait-for-mock-emails)))
+  (is (= 2 (count @email/mock-emails)))
+  (is (= #{"fixture@example.org" "test@example.org"}
+         (into #{} (map first) @email/mock-emails)))
+  (is (every? #(= "A permission was added to the group org.clojars.dantheman"
+                  %)
+              (into [] (map second) @email/mock-emails)))
+  (is (every? #(str/starts-with? % "User 'fixture' was added to the org.clojars.dantheman group with scope '*' by dantheman.\n\n")
+              (into [] (map #(nth % 2)) @email/mock-emails))))
+
+(deftest admin-can-toggle-member-to-admin
+  (-> (session (help/app))
+      (register-as "fixture" "fixture@example.org" "password"))
+  (-> (session (help/app))
+      (register-as "dantheman" "test@example.org" "password")
+      (visit "/groups/org.clojars.dantheman")
+      (fill-in [:#username] "fixture")
+      (press "Add Permission")
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td enlive/first-of-type]]
+        (has (text? "fixture")))
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td (enlive/nth-of-type 2)]]
+        (has (text? "*")))
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td (enlive/nth-of-type 3)]]
+        (has (text? "No"))))
+
+  (help/match-audit {:username "dantheman"}
+                    {:tag "permission-added"
+                     :user "dantheman"
+                     :group_name "org.clojars.dantheman"
+                     :message "user 'fixture' added as member with '*' scope"})
+
+  (email/expect-mock-emails 2)
+  (-> (session (help/app))
+      (login-as "dantheman" "password")
+      (visit "/groups/org.clojars.dantheman")
+      (press "Toggle Admin")
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td enlive/first-of-type]]
+        (has (text? "fixture")))
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td (enlive/nth-of-type 2)]]
+        (has (text? "*")))
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td (enlive/nth-of-type 3)]]
+        (has (text? "Yes"))))
+
+  (help/match-audit {:username "dantheman"}
+                    {:tag "permission-added"
+                     :user "dantheman"
+                     :group_name "org.clojars.dantheman"
+                     :message "user 'fixture' added as admin with '*' scope"})
+
+  (is (true? (email/wait-for-mock-emails)))
+  (is (= 2 (count @email/mock-emails)))
+  (is (= #{"fixture@example.org" "test@example.org"}
+         (into #{} (map first) @email/mock-emails)))
+  (is (every? #(= "An admin permission was added to the group org.clojars.dantheman"
+                  %)
+              (into [] (map second) @email/mock-emails)))
+  (is (every? #(str/starts-with? % "User 'fixture' was added as an admin to the org.clojars.dantheman group with scope '*' by dantheman.\n\n")
+              (into [] (map #(nth % 2)) @email/mock-emails))))
+
+(deftest admin-can-add-admin-to-group
+  (-> (session (help/app))
+      (register-as "fixture" "fixture@example.org" "password"))
+  (-> (session (help/app))
+      (register-as "dantheman" "test@example.org" "password")
+      ((fn [session] (email/expect-mock-emails 2) session))
+      (visit "/groups/org.clojars.dantheman")
+      (fill-in [:#username] "fixture")
+      (check [:#admin])
+      (press "Add Permission")
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td enlive/first-of-type]]
+        (has (text? "fixture")))
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td (enlive/nth-of-type 2)]]
+        (has (text? "*")))
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td (enlive/nth-of-type 3)]]
+        (has (text? "Yes"))))
+
+  (is (some #{"fixture"} (db/group-adminnames help/*db* "org.clojars.dantheman" db/SCOPE-ALL)))
+
+  (help/match-audit {:username "dantheman"}
+                    {:tag "permission-added"
+                     :user "dantheman"
+                     :group_name "org.clojars.dantheman"
+                     :message "user 'fixture' added as admin with '*' scope"})
+
+  (is (true? (email/wait-for-mock-emails)))
+  (is (= 2 (count @email/mock-emails)))
+  (is (= #{"fixture@example.org" "test@example.org"}
+         (into #{} (map first) @email/mock-emails)))
+  (is (every? #(= "An admin permission was added to the group org.clojars.dantheman"
+                  %)
+              (into [] (map second) @email/mock-emails)))
+  (is (every? #(str/starts-with? % "User 'fixture' was added as an admin to the org.clojars.dantheman group with scope '*' by dantheman.\n\n")
+              (into [] (map #(nth % 2)) @email/mock-emails))))
+
+(deftest admin-can-remove-user-from-group
+  (-> (session (help/app))
+      (register-as "fixture" "fixture@example.org" "password"))
+  (-> (session (help/app))
+      (register-as "dantheman" "test@example.org" "password")
+      (visit "/groups/org.clojars.dantheman")
+      (fill-in [:#username] "fixture")
+      ((fn [session] (email/expect-mock-emails 2) session))
+      (press "Add Permission")
+      ((fn [session]
+         ;; clear the add emails
+         (email/wait-for-mock-emails 1000)
+         ;; Then prep for the remove emails
+         (email/expect-mock-emails 2)
+         session))
+      (press "Remove Permission"))
+  (help/match-audit {:username "dantheman"}
+                    {:tag "permission-removed"
+                     :user "dantheman"
+                     :group_name "org.clojars.dantheman"
+                     :message "user 'fixture' with scope '*' removed"})
+
+  (is (true? (email/wait-for-mock-emails)))
+  (is (= 2 (count @email/mock-emails)))
+  (is (= #{"fixture@example.org" "test@example.org"}
+         (into #{} (map first) @email/mock-emails)))
+  (is (every? #(= "A permission was removed from the group org.clojars.dantheman"
+                  %)
+              (into [] (map second) @email/mock-emails)))
+  (is (every? #(str/starts-with? % "User 'fixture' was removed from the org.clojars.dantheman group with scope '*' by dantheman.\n\n")
+              (into [] (map #(nth % 2)) @email/mock-emails))))
+
+(deftest user-must-exist-to-be-added-to-group
+  (-> (session (help/app))
+      (register-as "dantheman" "test@example.org" "password")
+      (visit "/groups/org.clojars.dantheman")
+      (fill-in [:#username] "fixture")
+      (press "Add Permission")
+      (within [:div.error :ul :li]
+        (has (text? "No such user: fixture")))))
+
+(deftest user-can-be-scoped-to-jars
+  (-> (session (help/app))
+      (register-as "fixture" "fixture@example.org" "password"))
+  (-> (session (help/app))
+      (register-as "dantheman" "test@example.org" "password"))
+  ;; Add jars so they show in select
+  (db/add-jar help/*db* "dantheman"
+              {:group "org.clojars.dantheman"
+               :name "test"
+               :version "0.0.1"})
+  (db/add-jar help/*db* "dantheman"
+              {:group "org.clojars.dantheman"
+               :name "test2"
+               :version "0.0.1"})
+  (-> (session (help/app))
+      (login-as "dantheman" "password")
+      (visit "/groups/org.clojars.dantheman")
+      (fill-in [:#username] "fixture")
+      (check [:#admin])
+      (choose [:#scope_to_jar_select] "test")
+      (press "Add Permission")
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td enlive/first-of-type]]
+        (has (text? "fixture")))
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td (enlive/nth-of-type 2)]]
+        (has (text? "test")))
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td (enlive/nth-of-type 3)]]
+        (has (text? "Yes")))
+      (visit "/groups/org.clojars.dantheman")
+      (fill-in [:#username] "fixture")
+      (check [:#admin])
+      (choose [:#scope_to_jar_select] "test2")
+      (press "Add Permission")
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td enlive/first-of-type]]
+        (has (text? "fixture")))
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td (enlive/nth-of-type 2)]]
+        (has (text? "test2")))
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td (enlive/nth-of-type 3)]]
+        (has (text? "Yes")))))
+
+(deftest user-can-be-toggled-with-scoping
+  (-> (session (help/app))
+      (register-as "fixture" "fixture@example.org" "password"))
+  (-> (session (help/app))
+      (register-as "dantheman" "test@example.org" "password"))
+  ;; Add jars so they show in select
+  (db/add-jar help/*db* "dantheman"
+              {:group "org.clojars.dantheman"
+               :name "test"
+               :version "0.0.1"})
+  (-> (session (help/app))
+      (login-as "dantheman" "password")
+      (visit "/groups/org.clojars.dantheman")
+      (fill-in [:#username] "fixture")
+      (check [:#admin])
+      (choose [:#scope_to_jar_select] "test")
+      (press "Add Permission")
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td enlive/first-of-type]]
+        (has (text? "fixture")))
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td (enlive/nth-of-type 2)]]
+        (has (text? "test")))
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td (enlive/nth-of-type 3)]]
+        (has (text? "Yes")))
+      (visit "/groups/org.clojars.dantheman")
+      (fill-in [:#username] "fixture")
+      (choose [:#scope_to_jar_select] "test")
+      (press "Add Permission")
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td enlive/first-of-type]]
+        (has (text? "fixture")))
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td (enlive/nth-of-type 2)]]
+        (has (text? "test")))
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td (enlive/nth-of-type 3)]]
+        (has (text? "No")))))
+
+(deftest user-can-be-scoped-to-new-jar
+  (-> (session (help/app))
+      (register-as "fixture" "fixture@example.org" "password"))
+  (-> (session (help/app))
+      (register-as "dantheman" "test@example.org" "password"))
+  (-> (session (help/app))
+      (login-as "dantheman" "password")
+      (visit "/groups/org.clojars.dantheman")
+      (fill-in [:#username] "fixture")
+      (check [:#admin])
+      (choose [:#scope_to_jar_select] ":new")
+      (fill-in [:#scope_to_jar_new] "test")
+      (press "Add Permission")
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td enlive/first-of-type]]
+        (has (text? "fixture")))
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td (enlive/nth-of-type 2)]]
+        (has (text? "test")))
+      (within [:table.group-member-list
+               [:tr enlive/last-of-type]
+               [:td (enlive/nth-of-type 3)]]
+        (has (text? "Yes")))))
+
+(deftest user-cannot-be-scoped-to-jar-when-is-all-scoped
+  (-> (session (help/app))
+      (register-as "fixture" "fixture@example.org" "password"))
+  (-> (session (help/app))
+      (register-as "fixture2" "fixture@example.org" "password"))
+  (-> (session (help/app))
+      (register-as "dantheman" "test@example.org" "password"))
+  ;; Add jars so they show in select
+  (db/add-jar help/*db* "dantheman"
+              {:group "org.clojars.dantheman"
+               :name "test"
+               :version "0.0.1"})
+  (testing "As admin for all scope"
+    (-> (session (help/app))
+        (login-as "dantheman" "password")
+        (visit "/groups/org.clojars.dantheman")
+        (fill-in [:#username] "fixture")
+        (check [:#admin])
+        (press "Add Permission")
+        (within [:table.group-member-list
+                 [:tr enlive/last-of-type]
+                 [:td enlive/first-of-type]]
+          (has (text? "fixture")))
+        (within [:table.group-member-list
+                 [:tr enlive/last-of-type]
+                 [:td (enlive/nth-of-type 2)]]
+          (has (text? "*")))
+        (within [:table.group-member-list
+                 [:tr enlive/last-of-type]
+                 [:td (enlive/nth-of-type 3)]]
+          (has (text? "Yes")))
+
+        ;; As admin for project scope
+        (visit "/groups/org.clojars.dantheman")
+        (fill-in [:#username] "fixture")
+        (choose [:#scope_to_jar_select] "test")
+        (check [:#admin])
+        (press "Add Permission")
+        (within [:div.error :ul :li]
+          (has (text? "User has '*' scope, so can't be further scoped")))
+
+        ;; As member for project scope
+        (visit "/groups/org.clojars.dantheman")
+        (fill-in [:#username] "fixture")
+        (choose [:#scope_to_jar_select] "test")
+        (press "Add Permission")
+        (within [:div.error :ul :li]
+          (has (text? "User has '*' scope, so can't be further scoped")))))
+
+  (testing "As member for all scope"
+    (-> (session (help/app))
+        (login-as "dantheman" "password")
+        (visit "/groups/org.clojars.dantheman")
+        (fill-in [:#username] "fixture2")
+        (press "Add Permission")
+        (within [:table.group-member-list
+                 [:tr enlive/last-of-type]
+                 [:td enlive/first-of-type]]
+          (has (text? "fixture2")))
+        (within [:table.group-member-list
+                 [:tr enlive/last-of-type]
+                 [:td (enlive/nth-of-type 2)]]
+          (has (text? "*")))
+        (within [:table.group-member-list
+                 [:tr enlive/last-of-type]
+                 [:td (enlive/nth-of-type 3)]]
+          (has (text? "No")))
+
+        ;; As admin for project scope
+        (visit "/groups/org.clojars.dantheman")
+        (fill-in [:#username] "fixture2")
+        (choose [:#scope_to_jar_select] "test")
+        (check [:#admin])
+        (press "Add Permission")
+        (within [:div.error :ul :li]
+          (has (text? "User has '*' scope, so can't be further scoped")))
+
+        ;; As member for project scope
+        (visit "/groups/org.clojars.dantheman")
+        (fill-in [:#username] "fixture2")
+        (choose [:#scope_to_jar_select] "test")
+        (press "Add Permission")
+        (within [:div.error :ul :li]
+          (has (text? "User has '*' scope, so can't be further scoped"))))))
+
+(deftest user-cannot-be-scoped-to-all-when-caller-is-scoped-to-jar
+  (-> (session (help/app))
+      (register-as "fixture" "fixture@example.org" "password"))
+  (-> (session (help/app))
+      (register-as "fixture2" "fixture@example.org" "password"))
+  (-> (session (help/app))
+      (register-as "dantheman" "test@example.org" "password"))
+  ;; Add jars so they show in select
+  (db/add-jar help/*db* "dantheman"
+              {:group "org.clojars.dantheman"
+               :name "test"
+               :version "0.0.1"})
+  (-> (session (help/app))
+      (login-as "dantheman" "password")
+      (visit "/groups/org.clojars.dantheman")
+      (fill-in [:#username] "fixture")
+      (choose [:#scope_to_jar_select] "test")
+      (check [:#admin])
+      (press "Add Permission"))
+  (-> (session (help/app))
+      (login-as "fixture" "password")
+      ;; The UI hides invalid options from us, so we have to make the request
+      ;; manually
+      (p/request "/groups" :request-method :post
+                 :params {:username "fixture2"
+                          :admin "1"})
+      (help/assert-status 403)))
+
+(deftest user-cannot-be-scoped-to-jar-that-caller-does-not-have-access-to
+  (-> (session (help/app))
+      (register-as "fixture" "fixture@example.org" "password"))
+  (-> (session (help/app))
+      (register-as "fixture2" "fixture@example.org" "password"))
+  (-> (session (help/app))
+      (register-as "dantheman" "test@example.org" "password"))
+  ;; Add jars so they show in select
+  (db/add-jar help/*db* "dantheman"
+              {:group "org.clojars.dantheman"
+               :name "test"
+               :version "0.0.1"})
+  (db/add-jar help/*db* "dantheman"
+              {:group "org.clojars.dantheman"
+               :name "test2"
+               :version "0.0.1"})
+  (-> (session (help/app))
+      (login-as "dantheman" "password")
+      (visit "/groups/org.clojars.dantheman")
+      (fill-in [:#username] "fixture")
+      (choose [:#scope_to_jar_select] "test")
+      (check [:#admin])
+      (press "Add Permission"))
+  (-> (session (help/app))
+      (login-as "fixture" "password")
+      ;; The UI hides invalid options from us, so we have to make the request
+      ;; manually
+      (p/request "/groups" :request-method :post
+                 :params {:username "fixture2"
+                          :scope_to_jar_select "test2"
+                          :admin "1"})
+      (help/assert-status 403)))
+
+(deftest user-cannot-be-scoped-to-all-when-is-jar-scoped
+  (-> (session (help/app))
+      (register-as "fixture" "fixture@example.org" "password"))
+  (-> (session (help/app))
+      (register-as "fixture2" "fixture@example.org" "password"))
+  (-> (session (help/app))
+      (register-as "dantheman" "test@example.org" "password"))
+  ;; Add jars so they show in select
+  (db/add-jar help/*db* "dantheman"
+              {:group "org.clojars.dantheman"
+               :name "test"
+               :version "0.0.1"})
+  (testing "As admin for jar scope"
+    (-> (session (help/app))
+        (login-as "dantheman" "password")
+        (visit "/groups/org.clojars.dantheman")
+        (fill-in [:#username] "fixture")
+        (choose [:#scope_to_jar_select] "test")
+        (check [:#admin])
+        (press "Add Permission")
+        (within [:table.group-member-list
+                 [:tr enlive/last-of-type]
+                 [:td enlive/first-of-type]]
+          (has (text? "fixture")))
+        (within [:table.group-member-list
+                 [:tr enlive/last-of-type]
+                 [:td (enlive/nth-of-type 2)]]
+          (has (text? "test")))
+        (within [:table.group-member-list
+                 [:tr enlive/last-of-type]
+                 [:td (enlive/nth-of-type 3)]]
+          (has (text? "Yes")))
+
+        ;; As admin for all scope
+        (visit "/groups/org.clojars.dantheman")
+        (fill-in [:#username] "fixture")
+        (check [:#admin])
+        (press "Add Permission")
+        (within [:div.error :ul :li]
+          (has (text? "User has project scope, so can't be given '*' scope")))
+
+        ;; As member for project scope
+        (visit "/groups/org.clojars.dantheman")
+        (fill-in [:#username] "fixture")
+        (press "Add Permission")
+        (within [:div.error :ul :li]
+          (has (text? "User has project scope, so can't be given '*' scope")))))
+
+  (testing "As member for jar scope"
+    (-> (session (help/app))
+        (login-as "dantheman" "password")
+        (visit "/groups/org.clojars.dantheman")
+        (fill-in [:#username] "fixture2")
+        (choose [:#scope_to_jar_select] "test")
+        (press "Add Permission")
+        (within [:table.group-member-list
+                 [:tr enlive/last-of-type]
+                 [:td enlive/first-of-type]]
+          (has (text? "fixture2")))
+        (within [:table.group-member-list
+                 [:tr enlive/last-of-type]
+                 [:td (enlive/nth-of-type 2)]]
+          (has (text? "test")))
+        (within [:table.group-member-list
+                 [:tr enlive/last-of-type]
+                 [:td (enlive/nth-of-type 3)]]
+          (has (text? "No")))
+
+        ;; As admin for all scope
+        (visit "/groups/org.clojars.dantheman")
+        (fill-in [:#username] "fixture2")
+        (check [:#admin])
+        (press "Add Permission")
+        (within [:div.error :ul :li]
+          (has (text? "User has project scope, so can't be given '*' scope")))
+
+        ;; As member for all scope
+        (visit "/groups/org.clojars.dantheman")
+        (fill-in [:#username] "fixture2")
+        (press "Add Permission")
+        (within [:div.error :ul :li]
+          (has (text? "User has project scope, so can't be given '*' scope"))))))
+
+

--- a/test/clojars/test_helper.clj
+++ b/test/clojars/test_helper.clj
@@ -113,13 +113,14 @@
   (binding [config/*profile* "test"]
     ;; double binding since ^ needs to be bound for config to load
     ;; properly
-    (binding [system (component/start (assoc (system/new-system (config/config))
-                                             :repo-bucket (s3/mock-s3-client)
-                                             :error-reporter (quiet-reporter)
-                                             :index-factory memory-index
-                                             :mailer (email/mock-mailer)
-                                             :stats (no-stats)
-                                             :github (oauth-service/new-mock-oauth-service "GitHub" {})))]
+    (binding [system (component/start
+                      (assoc (system/new-system (config/config))
+                             :repo-bucket (s3/mock-s3-client)
+                             :error-reporter (quiet-reporter)
+                             :index-factory memory-index
+                             :mailer (email/mock-mailer)
+                             :stats (no-stats)
+                             :github (oauth-service/new-mock-oauth-service "GitHub" {})))]
       (let [db (get-in system [:db :spec])]
         (try
           (clear-database db)
@@ -203,3 +204,7 @@
           (Thread/sleep 1000)
           (recur (inc attempt)))
         false))))
+
+(defn assert-status
+  [session status]
+  (is (= status (get-in session [:response :status]))))

--- a/test/clojars/unit/friend/oauth/github_test.clj
+++ b/test/clojars/unit/friend/oauth/github_test.clj
@@ -85,7 +85,7 @@
         (is (db/find-group-verification help/*db* "io.github.jd2"))))
 
     (testing "with a valid user but group already exists"
-      (db/add-admin help/*db* "com.github.johnd" "someone" "clojars")
+      (db/add-admin help/*db* "com.github.johnd" db/SCOPE-ALL "someone" "clojars")
       (set-mock-responses
        [{:email "john.doe@example.org"
          :primary true

--- a/test/clojars/unit/friend/oauth/gitlab_test.clj
+++ b/test/clojars/unit/friend/oauth/gitlab_test.clj
@@ -75,7 +75,7 @@
         (is (db/find-group-verification help/*db* "io.gitlab.jd2"))))
 
     (testing "with a valid user but group already exists"
-      (db/add-admin help/*db* "com.gitlab.johnd" "someone" "clojars")
+      (db/add-admin help/*db* "com.gitlab.johnd" db/SCOPE-ALL "someone" "clojars")
       (set-mock-responses "john.doe@example.org" "johnd")
 
       (let [req {:uri "/oauth/gitlab/callback"

--- a/test/clojars/unit/verification_test.clj
+++ b/test/clojars/unit/verification_test.clj
@@ -87,8 +87,8 @@
     (db/add-group help/*db* "dantheman" "com.foo")
     ;; We have to have some other member for the group to be considered to
     ;; exist.
-    (db/add-member help/*db* "com.foo" "anotheruser" "testing")
-    (db/inactivate-member help/*db* "com.foo" "dantheman" "testing")
+    (db/add-member help/*db* "com.foo" db/SCOPE-ALL "anotheruser" "testing")
+    (db/inactivate-member help/*db* "com.foo" db/SCOPE-ALL "dantheman" "testing")
     (help/with-TXT records
       (is (match?
            {:txt-records records


### PR DESCRIPTION
### Rename groups table to permissions

This better captures what it is used for, and preps us for having
jar-level permissions in the future.

### Add project-scoped permissions

This will allow group admins to give admin or just deploy rights to
users for individual projects within the group.

Implements #709.


Screenshot of the updates to the group management page:

![image](https://github.com/clojars/clojars-web/assets/2631/0923accb-bf5a-4f3a-87d3-617ffa0c142b)
