### PR TITLE
Report validity to GitHub when scanning tokens

### DIFF
--- a/test/clojars/unit/web/token_breach_test.clj
+++ b/test/clojars/unit/web/token_breach_test.clj
@@ -28,10 +28,12 @@
                   :is_current true}]})
 
 (defn- build-breach-request
-  [token-value]
-  (let [payload [{:token token-value
-                  :type "whatever"
-                  :url "https://github.com/foo/bar"}]
+  [& token-values]
+  (let [payload (mapv (fn [token-value]
+                        {:token token-value
+                         :type "whatever"
+                         :url "https://github.com/foo/bar"})
+                      token-values)
         payload-str (json/encode payload)
         sig (dsa/sign payload-str {:key privkey :alg :ecdsa+sha256})
         sig-b64 (String. (base64/encode sig))]
@@ -59,11 +61,16 @@
     (with-redefs [client/get (constantly {:body github-response})]
       (testing "when token is enabled"
         (let [token (db/add-deploy-token help/*db* "ham" "a token" nil nil false nil)
-              res (app (build-breach-request (:token token)))
+              token-str (:token token)
+              res (app (build-breach-request token-str))
               db-token (find-token "ham" "a token")
               _ (is (true? (email/wait-for-mock-emails)))
               [to subject message] (first @email/mock-emails)]
           (is (= 200 (:status res)))
+          (is (= [{:token_raw token-str
+                   :token_type "whatever"
+                   :label "true_positive"}]
+                 (:body res)))
           (is (:disabled db-token))
           (is (= "ham@biscuit.co" to))
           (is (= "Deploy token found on GitHub" subject))
@@ -73,15 +80,35 @@
 
       (testing "when token is disabled"
         (let [token (db/add-deploy-token help/*db* "ham" "another token" nil nil false nil)
+              token-str (:token token)
               db-token (find-token "ham" "another token")
               _ (db/disable-deploy-token help/*db* (:id db-token))
               _ (email/expect-mock-emails 1)
-              res (app (build-breach-request (:token token)))
+              res (app (build-breach-request token-str))
               _ (is (true? (email/wait-for-mock-emails)))
               [to subject message] (first @email/mock-emails)]
           (is (= 200 (:status res)))
+          (is (= [{:token_raw token-str
+                   :token_type "whatever"
+                   :label "true_positive"}]
+                 (:body res)))
           (is (= "ham@biscuit.co" to))
           (is (= "Deploy token found on GitHub" subject))
           (is (re-find #"'another token'" message))
           (is (re-find #"https://github.com/foo/bar" message))
-          (is (re-find #"was already disabled" message)))))))
+          (is (re-find #"was already disabled" message))))
+
+      (testing "with existing and non-existent tokens"
+        (let [token (db/add-deploy-token help/*db* "ham" "a token" nil nil false nil)
+              token-str (:token token)
+              res (app (build-breach-request token-str "non-existent-token"))
+              db-token (find-token "ham" "a token")]
+          (is (= 200 (:status res)))
+          (is (= [{:token_raw token-str
+                   :token_type "whatever"
+                   :label "true_positive"}
+                  {:token_raw "non-existent-token"
+                   :token_type "whatever"
+                   :label "false_positive"}]
+                 (:body res)))
+          (is (:disabled db-token)))))))


### PR DESCRIPTION
GitHub supports[1] returning the validity (true or false positive) for
Clojars deploy tokens that it reports to us. This implements that
response.

Fixes #879.

[1]:
https://docs.github.com/en/enterprise-cloud@latest/code-security/secret-scanning/secret-scanning-partner-program#provide-feedback-for-false-positives