### PR TITLE
Ensure emails are downcased; don't allow future duplicate email usage

### DIFF
--- a/src/clojars/db.clj
+++ b/src/clojars/db.clj
@@ -144,7 +144,7 @@
        :from :users
        :where [:or
                [:= :user username-or-email]
-               [:= :email username-or-email]]
+               [:= :email (str/lower-case username-or-email)]]
        :limit 1})))
 
 (defn find-user-by-email-in
@@ -153,7 +153,7 @@
    (q db
       {:select :*
        :from :users
-       :where [:in :email emails]
+       :where [:in :email (mapv str/lower-case emails)]
        :limit 1})))
 
 (defn find-user-by-password-reset-code
@@ -678,7 +678,7 @@
 
 (defn add-user
   [db email username password]
-  (let [record {:email email
+  (let [record {:email (str/lower-case email)
                 :username username
                 :password (bcrypt password)
                 :send_deploy_emails true
@@ -695,7 +695,7 @@
                (cond-> {:email email}
                  (seq password) (assoc :password (bcrypt password)))
                {user-column account})
-  {:email    email
+  {:email    (str/lower-case email)
    :username account
    :account  account})
 

--- a/src/clojars/friend/registration.clj
+++ b/src/clojars/friend/registration.clj
@@ -3,12 +3,12 @@
    [cemerick.friend.workflows :as workflow]
    [clojars.db :refer [add-user]]
    [clojars.log :as log]
-   [clojars.web.user :refer [register-form new-user-validations]]
+   [clojars.web.user :refer [register-form new-user-validations normalize-email]]
    [ring.util.response :refer [response content-type]]
    [valip.core :refer [validate]]))
 
 (defn register [db {:keys [email username password confirm]}]
-  (let [email (and email (.trim email))]
+  (let [email (normalize-email email)]
     (log/with-context {:email email
                        :username username
                        :tag :registration}

--- a/src/clojars/time.clj
+++ b/src/clojars/time.clj
@@ -19,9 +19,9 @@
      ~@body))
 
 (defn days-ago
-  ([days]
+  (^Instant [days]
    (days-ago (now) days))
-  ([^Instant instant ^long days]
+  (^Instant [^Instant instant ^long days]
    (.minus instant days ChronoUnit/DAYS)))
 
 (defn days-from

--- a/src/clojars/web/user.clj
+++ b/src/clojars/web/user.clj
@@ -56,11 +56,6 @@
                                       :confirm)
                       (submit-button "Register"))]))
 
-(defn conj-when [coll test x]
-  (if test
-    (conj coll x)
-    coll))
-
 ;; Validations
 
 (defn password-validations [confirm]

--- a/test/clojars/integration/group_permissions_test.clj
+++ b/test/clojars/integration/group_permissions_test.clj
@@ -328,7 +328,7 @@
   (-> (session (help/app))
       (register-as "fixture" "fixture@example.org" "password"))
   (-> (session (help/app))
-      (register-as "fixture2" "fixture@example.org" "password"))
+      (register-as "fixture2" "fixture2@example.org" "password"))
   (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password"))
   ;; Add jars so they show in select
@@ -474,7 +474,7 @@
   (-> (session (help/app))
       (register-as "fixture" "fixture@example.org" "password"))
   (-> (session (help/app))
-      (register-as "fixture2" "fixture@example.org" "password"))
+      (register-as "fixture2" "fixture2@example.org" "password"))
   (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password"))
   ;; Add jars so they show in select

--- a/test/clojars/integration/users_test.clj
+++ b/test/clojars/integration/users_test.clj
@@ -103,7 +103,26 @@
       (press "Register")
       (has (status? 200))
       (within [:div.error :ul :li]
-        (has (text? "Email can't be blankEmail must have an @ sign and a domain")))
+        (has (text? "Email can't be blankEmail is not valid")))
+
+      (fill-in "Email" "not-an-email@adf@")
+      (fill-in "Username" "dantheman")
+      (fill-in "Password" "password")
+      (fill-in "Confirm password" "password")
+      (press "Register")
+      (has (status? 200))
+      (within [:div.error :ul :li]
+        (has (text? "Email is not valid")))
+
+      (fill-in "Email" (apply str "too-long@foo."
+                              (repeat 250 "a")))
+      (fill-in "Username" "dantheman")
+      (fill-in "Password" "password")
+      (fill-in "Confirm password" "password")
+      (press "Register")
+      (has (status? 200))
+      (within [:div.error :ul :li]
+        (has (text? "Email is not valid")))
 
       (fill-in "Email" "test@example.org")
       (fill-in "Username" "")
@@ -265,7 +284,7 @@
       (press "Update")
       (has (status? 200))
       (within [:div.error :ul :li]
-        (has (text? "Email can't be blankEmail must have an @ sign and a domain")))))
+        (has (text? "Email can't be blankEmail is not valid")))))
 
 (deftest user-can-get-new-password
   (email/expect-mock-emails 1)

--- a/test/clojars/integration/users_test.clj
+++ b/test/clojars/integration/users_test.clj
@@ -1,5 +1,6 @@
 (ns clojars.integration.users-test
   (:require
+   [clojars.db :as db]
    [clojars.email :as email]
    [clojars.integration.steps :refer [disable-mfa enable-mfa login-as register-as]]
    ;; for defmethods
@@ -23,6 +24,15 @@
       (has (status? 200))
       (within [:div.light-article :> :h1]
         (has (text? "Dashboard (dantheman)")))))
+
+(deftest user-registering-with-upcase-email-gets-downcased
+  (-> (session (help/app))
+      (register-as "dantheman" "Test@example.org" "password")
+      (follow-redirect)
+      (has (status? 200))
+      (within [:div.light-article :> :h1]
+        (has (text? "Dashboard (dantheman)"))))
+  (is (= "test@example.org" (:email (db/find-user help/*db* "dantheman")))))
 
 (deftest bad-registration-info-should-show-error
   (-> (session (help/app))

--- a/test/clojars/unit/friend/oauth/github_test.clj
+++ b/test/clojars/unit/friend/oauth/github_test.clj
@@ -84,6 +84,27 @@
         (is (db/find-group-verification help/*db* "com.github.jd2"))
         (is (db/find-group-verification help/*db* "io.github.jd2"))))
 
+    (testing "with a valid upcased email"
+      (db/add-user help/*db* "john.doe3@example.org" "johndoe3" "pwd12345")
+      (set-mock-responses
+       [{:email "John.doe3@example.org"
+         :primary true
+         :verified true}]
+       "jd3")
+
+      (let [req {:uri "/oauth/github/callback"
+                 :params {:code "1234567890"}}
+            response (handle-workflow req)
+
+            {:keys [auth-provider identity provider-login username]} response]
+
+        (is (= "GitHub" auth-provider))
+        (is (= "johndoe3" identity))
+        (is (= "jd3" provider-login))
+        (is (= "johndoe3" username))
+        (is (db/find-group-verification help/*db* "com.github.jd3"))
+        (is (db/find-group-verification help/*db* "io.github.jd3"))))
+
     (testing "with a valid user but group already exists"
       (db/add-admin help/*db* "com.github.johnd" db/SCOPE-ALL "someone" "clojars")
       (set-mock-responses


### PR DESCRIPTION
### Eliminate reflection

### Remove unused code

### Ensure emails are stored & queried as downcased

This will ensure that any new email we write to the db will be
downcased, and any query will downcase the email first before querying.
This is to ensure that users don't accidentally create multiple users
with semantically the same email address.

There are 118 existing users that have email addresses containing
uppercase characters. Of those, 10 of them have a *different* user with
the downcased email. All of these will need to be addressed as part of
releasing this change.

### Don't allow using an existing email

This prevents creating a new user or updating an existing user with the
email address of another user. This does not add a uniqueness constraint
to the database for the email address because we currently have 511
email addresses that are in use across at least 2 user records.