### PR TITLE
Upgrade to Jetty 11

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -16,7 +16,7 @@
   clj-http/clj-http {:mvn/version "3.12.3"}
   clj-stacktrace/clj-stacktrace {:mvn/version "0.2.8"}
   com.cemerick/friend {:mvn/version "0.2.3"
-                       :exclusions [;; not used, excluded to address CVE-2007-1652, CVE-2007-1651
+                       :exclusions [ ;; not used, excluded to address CVE-2007-1652, CVE-2007-1651
                                     org.openid4java/openid4java-nodeps
                                     ;; not used, excluded to address CVE-2012-0881, CVE-2013-4002, CVE-2009-2625
                                     net.sourceforge.nekohtml/nekohtml]}
@@ -64,6 +64,10 @@
   org.clojure/tools.logging {:mvn/version "1.2.4"}
   org.clojure/tools.nrepl {:mvn/version "0.2.11"}
   org.postgresql/postgresql {:mvn/version "42.7.2"}
+  ;; Having this as a top-level dep instead of having it come in transitively
+  ;; allows logging to be properly configured instead of going to stdout, and I
+  ;; don't know why! - Toby 2024-05-05
+  org.slf4j/slf4j-api {:mvn/version "2.0.13"}
   org.tcrawley/cognitect-http-client {:mvn/version "1.11.129"}
 
   net.cgrand/regex {:mvn/version "1.0.1"}
@@ -80,7 +84,7 @@
  :aliases {:defaults
            ;; We use override-deps to address CVEs
            {:override-deps
-            {;; Addreses CVE-2022-42004, CVE-2022-42003, CVE-2021-46877, CVE-2020-36518
+            { ;; Addreses CVE-2022-42004, CVE-2022-42003, CVE-2021-46877, CVE-2020-36518
              com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.15.2"}
              ;; Addreses CVE-2019-10086, CVE-2014-0114
              commons-beanutils/commons-beanutils {:mvn/version "1.9.4"}

--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,9 @@
                                     org.openid4java/openid4java-nodeps
                                     ;; not used, excluded to address CVE-2012-0881, CVE-2013-4002, CVE-2009-2625
                                     net.sourceforge.nekohtml/nekohtml]}
-  com.cognitect.aws/api {:mvn/version "0.8.681"}
+  com.cognitect.aws/api {:mvn/version "0.8.692"
+                         ;; we use org.tcrawley/cognitect-http-client instead to use Jetty 11
+                         :exclusions [com.cognitect/http-client]}
   com.cognitect.aws/endpoints {:mvn/version "1.1.12.489"}
   com.cognitect.aws/s3 {:mvn/version "847.2.1398.0"}
   com.cognitect.aws/sqs {:mvn/version "847.2.1398.0"}
@@ -58,24 +60,18 @@
   ;; CVE-2024-30171, CVE-2024-30172
   org.bouncycastle/bcpkix-jdk18on {:mvn/version "1.78"}
   org.bouncycastle/bcprov-jdk18on {:mvn/version "1.78"}
-  org.clojure/clojure {:mvn/version "1.11.2"}
+  org.clojure/clojure {:mvn/version "1.11.3"}
   org.clojure/tools.logging {:mvn/version "1.2.4"}
   org.clojure/tools.nrepl {:mvn/version "0.2.11"}
-  ;; Override jetty brought in by aws/api to address CVE-2023-40167,
-  ;; CVE-2023-41900, CVE-2023-36479
-  org.eclipse.jetty/jetty-client {:mvn/version "9.4.53.v20231009"}
-  ;; Override jetty brought in by ring-jetty-adapter to address CVE-2023-40167,
-  ;; CVE-2023-41900, CVE-2023-36479
-  org.eclipse.jetty/jetty-server {:mvn/version "9.4.53.v20231009"}
-
   org.postgresql/postgresql {:mvn/version "42.7.2"}
+  org.tcrawley/cognitect-http-client {:mvn/version "1.11.129"}
 
   net.cgrand/regex {:mvn/version "1.0.1"}
 
   raven-clj/raven-clj {:mvn/version "1.7.0"}
-  ring/ring-core {:mvn/version "1.10.0"}
-  ring/ring-defaults {:mvn/version "0.3.3"}
-  ring/ring-jetty-adapter {:mvn/version "1.10.0"}
+  ring/ring-core {:mvn/version "1.12.1"}
+  ring/ring-defaults {:mvn/version "0.5.0"}
+  ring/ring-jetty-adapter {:mvn/version "1.12.1"}
   ring-jetty-component/ring-jetty-component {:mvn/version "0.3.1"}
   ring-middleware-format/ring-middleware-format {:mvn/version "0.7.5"}
 

--- a/src/clojars/event.clj
+++ b/src/clojars/event.clj
@@ -87,8 +87,9 @@
                                                 (:message-wait-timeout config))))
                        (.start)))))
   (stop [this]
-    (reset! (:running? this) false)
-    (.join ^Thread (:thread this) 60000)
+    (when-some [running? (:running? this)]
+      (reset! running? false)
+      (.join ^Thread (:thread this) 60000))
     this))
 
 (defn new-sqs-receiver

--- a/src/clojars/ring_servlet_patch.clj
+++ b/src/clojars/ring_servlet_patch.clj
@@ -1,26 +1,44 @@
 (ns clojars.ring-servlet-patch
   (:import
-   (javax.servlet.http
+   (jakarta.servlet.http
+    HttpServletResponse
     HttpServletResponseWrapper)
    (org.eclipse.jetty.server
-    Request)
+    Response
+    Server)
    (org.eclipse.jetty.server.handler
-    AbstractHandler)))
+    HandlerWrapper)
+   (org.eclipse.jetty.servlet
+    ServletContextHandler)))
 
+(set! *warn-on-reflection* true)
 
-(defn response-wrapper [response]
+(defn response-wrapper
+  [^Response response]
   (proxy [HttpServletResponseWrapper] [response]
     (setHeader [name value]
       (if (and (= name "status-message") value)
-        (.setStatus response (.getStatus response) value)
-        (proxy-super setHeader name value)))))
+        ;; Jetty ignores the reason passed to HttpServletResponse#setStatus(),
+        ;; so we have to call a method on Jetty's response impl instead.
+        (.setStatusWithReason ^Response response (.getStatus response) value)
+        (.setHeader ^HttpServletResponse response name value)))))
 
-(defn handler-wrapper ^AbstractHandler [handler]
-  (proxy [AbstractHandler] []
-    (handle [target ^Request base-request request response]
-      (let [response (response-wrapper response)]
-        (.handle handler target base-request request response)))))
+(defn handler-wrapper
+  ^HandlerWrapper []
+  (proxy [HandlerWrapper] []
+    (handle [target base-request request response]
+      (let [response (response-wrapper response)
+            ;; This prevents reflection on the proxy-super call
+            ;; by hinting the explicit `this`.
+            ^HandlerWrapper this this]
+        (proxy-super handle target base-request request response)))))
 
-(defn use-status-message-header [server]
-  (let [handler (.getHandler server)]
-    (.setHandler server (handler-wrapper handler))))
+(defn use-status-message-header
+  "This adds a wrapper around the servlet handler to override .setHeader on the response.
+  We do this so we can set the status message of the response by smuggling it
+  through ring as a header, as this setting this is not exposed by ring.
+
+  The status message is used to provide additional context when deploying."
+  [^Server server]
+  (let [^ServletContextHandler handler (.getHandler server)]
+    (.insertHandler handler (handler-wrapper))))


### PR DESCRIPTION
### Make event component more resilient

If we run in to an error starting the system during development, we may
try to stop this component before it has started. This guards against
errors when doing that.

### Upgrade to Jetty 11

This upgrades us to ring 1.11, which moves from Jetty 9 to Jetty 11.
This includes using a fork of cognitect's http-client that works with
Jetty 11's client impl.

### Directly depend on slf4j-api

This is a bit of a mystery: if we let slf4j-api come in via a transitive
dependency, our logback.xml file is ignored (at least in dev & test), so
all logging goes to stdout. clojure.tools.logging is finding slj4j-api
in both cases, but logback does not get initialized in the case where
this isn't a top-level dep.

I have no idea why this is happening! Logging is terrible.