### PR TITLE
Add hcaptcha to signup form

### DIFF
--- a/resources/config.edn
+++ b/resources/config.edn
@@ -40,6 +40,10 @@
                        :client-secret #profile {:production #ssm-parameter "/clojars/production/gitlab_oauth_client_secret"
                                                 :default    "testing"}
                        :callback-uri  "https://clojars.org/oauth/gitlab/callback"}
+ :hcaptcha            #profile {:production {:site-key #ssm-parameter "/clojars/production/hcaptcha_site_key"
+                                             :secret #ssm-parameter "/clojars/production/hcaptcha_secret"}
+                                :default {:site-key "10000000-ffff-ffff-ffff-000000000001"
+                                          :secret "0x0000000000000000000000000000000000000000"}}
  :index-path          "data/index"
  :mail                #profile {:production {:from     "contact@clojars.org"
                                              :hostname "email-smtp.us-east-1.amazonaws.com"

--- a/src/clojars/config.clj
+++ b/src/clojars/config.clj
@@ -26,6 +26,10 @@
 
 (def ^:dynamic *profile* "development")
 
+(defn test-profile?
+  []
+  (= "test" *profile*))
+
 (defmethod aero/reader 'ssm-parameter
   [_opts _tag value]
   (if (= :production *profile*)

--- a/src/clojars/hcaptcha.clj
+++ b/src/clojars/hcaptcha.clj
@@ -1,0 +1,63 @@
+(ns clojars.hcaptcha
+  "See https://docs.hcaptcha.com/#verify-the-user-response-server-side"
+  (:require
+   [clojars.log :as log]
+   [clojars.remote-service :as remote-service :refer [defendpoint]]
+   [clojure.set :as set]))
+
+(def hcaptcha-csp
+  (let [hcaptcha-urls ["https://hcaptcha.com" "https://*.hcaptcha.com"]]
+    {:connect-src hcaptcha-urls
+     :frame-src   hcaptcha-urls
+     :script-src  hcaptcha-urls
+     :style-src   hcaptcha-urls}))
+
+(defrecord Hcaptcha [config])
+
+(defn site-key
+  [hcaptcha]
+  (get-in hcaptcha [:config :site-key]))
+
+(defn- secret
+  [hcaptcha]
+  (get-in hcaptcha [:config :secret]))
+
+(defendpoint -validate-hcaptcha-response
+  [_client site-key secret hcaptcha-response]
+  {:method :post
+   :url "https://api.hcaptcha.com/siteverify"
+   :form-params {:response hcaptcha-response
+                 :secret secret
+                 :site-key site-key}})
+
+;; These responses from hcaptcha indicate a misconfiguration or a code bug, so
+;; we will throw and error for them.
+(def ^:private invalid-error-codes
+  #{"bad-request"
+    "invalid-input-secret"
+    "invalid-or-already-seen-response"
+    "missing-input-secret"
+    "sitekey-secret-mismatch"})
+
+(defn- log-and-maybe-thrpw
+  [{:as _response :keys [error-codes success]}]
+  (let [log-data {:tag :hcaptcha-response
+                  :error-codes error-codes
+                  :success? success}]
+    (log/info log-data)
+    (when (seq (set/intersection invalid-error-codes (set error-codes)))
+      (throw (ex-info "Invalid hcaptcha configuration" log-data)))))
+
+(defn valid-response?
+  [hcaptcha hcaptcha-response]
+  (let [response (-validate-hcaptcha-response (:client hcaptcha)
+                                              (site-key hcaptcha)
+                                              (secret hcaptcha)
+                                              hcaptcha-response)]
+    (log-and-maybe-thrpw response)
+    (:success response)))
+
+(defn new-hcaptcha
+  [config]
+  (map->Hcaptcha {:config config
+                  :client (remote-service/new-http-remote-service)}))

--- a/src/clojars/log.clj
+++ b/src/clojars/log.clj
@@ -32,7 +32,7 @@
 
   java.util.List
   (redact [v]
-    (vec (map redact v)))
+    (mapv redact v))
 
   java.util.Map
   (redact [v]

--- a/src/clojars/routes/artifact.clj
+++ b/src/clojars/routes/artifact.clj
@@ -10,7 +10,7 @@
 (defn- with-shields-io-img-src
   "Allows shields.io badges to be shown on artifact pages."
   [body]
-  (http-utils/with-extra-img-src ["https://img.shields.io"] body))
+  (http-utils/with-extra-csp-srcs {:img-src ["https://img.shields.io"]} body))
 
 (defn show [db stats group-id artifact-id]
   (when-some [artifact (db/find-jar db group-id artifact-id)]

--- a/src/clojars/routes/user.clj
+++ b/src/clojars/routes/user.clj
@@ -4,6 +4,7 @@
    [clojars.auth :as auth]
    [clojars.db :as db]
    [clojars.event :as event]
+   [clojars.hcaptcha :as hcaptcha]
    [clojars.http-utils :as http-utils]
    [clojars.log :as log]
    [clojars.routes.common :as common]
@@ -115,7 +116,7 @@
         (assoc (redirect "/mfa")
                :flash "Password incorrect.")))))
 
-(defn routes [db event-emitter mailer]
+(defn routes [db event-emitter hcaptcha mailer]
   (compojure/routes
    (GET "/profile" {:keys [flash]}
         (auth/with-account
@@ -146,7 +147,8 @@
            #(view/update-notifications db % params)))
 
    (GET "/register" {:keys [params flash]}
-        (view/register-form params flash))
+        (http-utils/with-extra-csp-srcs hcaptcha/hcaptcha-csp
+          (view/register-form hcaptcha params flash)))
 
    (GET "/forgot-password" _
         (view/forgot-password-form))

--- a/src/clojars/routes/user.clj
+++ b/src/clojars/routes/user.clj
@@ -19,7 +19,7 @@
 (defn- with-data-img-src
   "Allows data: badges to be shown on the mfa page to allow the qrcode to load."
   [body]
-  (http-utils/with-extra-img-src ["data:"] body))
+  (http-utils/with-extra-csp-srcs {:img-src ["data:"]} body))
 
 (defn- create-mfa [db
                    account

--- a/src/clojars/system.clj
+++ b/src/clojars/system.clj
@@ -2,6 +2,7 @@
   (:require
    [clojars.email :refer [simple-mailer]]
    [clojars.event :as event]
+   [clojars.hcaptcha :as hcaptcha]
    [clojars.notifications :as notifications]
    ;; for defmethods
    [clojars.notifications.admin]
@@ -81,6 +82,7 @@
                                                      (:callback-uri gitlab-oauth))
           :event-emitter  (event/new-sqs-emitter (:event-queue config))
           :event-receiver (event/new-sqs-receiver (:event-queue config))
+          :hcaptcha       (hcaptcha/new-hcaptcha (:hcaptcha config))
           :http           (jetty-server (assoc (:http config)
                                                :configurator patch/use-status-message-header))
           :http-client    (remote-service/new-http-remote-service)
@@ -91,8 +93,8 @@
           :storage        (storage-component (:repo config) (:cdn-token config) (:cdn-url config))))
         (component/system-using
          {:app            [:clojars-app]
-          :clojars-app    [:db :github :gitlab :error-reporter :event-emitter :http-client
-                           :mailer :stats :search :storage]
+          :clojars-app    [:db :github :gitlab :error-reporter :event-emitter :hcaptcha
+                           :http-client :mailer :stats :search :storage]
           :event-emitter  [:error-reporter]
           :http           [:app]
           :notifications  [:db :mailer]

--- a/src/clojars/web.clj
+++ b/src/clojars/web.clj
@@ -50,7 +50,7 @@
                :status 400})))))
 
 (defn- main-routes
-  [{:as _system :keys [db event-emitter mailer search stats]}]
+  [{:as _system :keys [db event-emitter hcaptcha mailer search stats]}]
   (let [db (:spec db)]
     (routes
      (GET "/" _
@@ -83,7 +83,7 @@
      (artifact/routes db stats)
      ;; user routes must go after artifact routes
      ;; since they both catch /:identifier
-     (user/routes db event-emitter mailer)
+     (user/routes db event-emitter hcaptcha mailer)
      (verify/routes db event-emitter)
      (token/routes db)
      (api/routes db stats)
@@ -139,6 +139,7 @@
     :keys [db
            error-reporter
            event-emitter
+           hcaptcha
            http-client
            github
            gitlab
@@ -168,7 +169,7 @@
          (friend/authenticate
           {:credential-fn (auth/password-credential-fn db event-emitter)
            :workflows [(auth/interactive-form-with-mfa-workflow)
-                       (registration/workflow db)
+                       (registration/workflow db hcaptcha)
                        (github/workflow github http-client db)
                        (gitlab/workflow gitlab http-client db)]})
          (wrap-reject-invalid-params)

--- a/test/clojars/integration/steps.clj
+++ b/test/clojars/integration/steps.clj
@@ -24,6 +24,13 @@
        (cond-> otp (fill-in "Two-Factor Code" otp))
        (press "Login"))))
 
+(defn fill-in-captcha
+  ([state]
+   ;; From https://docs.hcaptcha.com/#integration-testing-test-keys
+   (fill-in-captcha state "10000000-aaaa-bbbb-cccc-000000000001"))
+  ([state value]
+   (fill-in state "TEST Captcha" value)))
+
 (defn register-as
   ([state user email password]
    (register-as state user email password password))
@@ -35,6 +42,7 @@
        (fill-in "Username" user)
        (fill-in "Password" password)
        (fill-in "Confirm password" confirm)
+       (fill-in-captcha)
        (press "Register"))))
 
 (defn create-deploy-token

--- a/test/clojars/integration/users_test.clj
+++ b/test/clojars/integration/users_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojars.db :as db]
    [clojars.email :as email]
-   [clojars.integration.steps :refer [disable-mfa enable-mfa login-as register-as]]
+   [clojars.integration.steps :refer [disable-mfa enable-mfa fill-in-captcha login-as register-as]]
    ;; for defmethods
    [clojars.notifications.user]
    [clojars.test-helper :as help]
@@ -72,6 +72,7 @@
 
       (fill-in "Email" "test@example.org")
       (fill-in "Username" "dantheman")
+      (fill-in-captcha)
       (press "Register")
       (has (status? 200))
       (within [:div.error :ul :li]
@@ -81,6 +82,7 @@
       (fill-in "Username" "dantheman")
       (fill-in "Password" (apply str (range 123)))
       (fill-in "Confirm password" (apply str (range 123)))
+      (fill-in-captcha)
       (press "Register")
       (has (status? 200))
       (within [:div.error :ul :li]
@@ -89,6 +91,7 @@
       (fill-in "Password" "password")
       (fill-in "Email" "test@example.com")
       (fill-in "Username" "dantheman")
+      (fill-in-captcha)
       (press "Register")
       (has (status? 200))
       (has (value? [:input#username] "dantheman"))
@@ -100,6 +103,7 @@
       (fill-in "Username" "dantheman")
       (fill-in "Password" "password")
       (fill-in "Confirm password" "password")
+      (fill-in-captcha)
       (press "Register")
       (has (status? 200))
       (within [:div.error :ul :li]
@@ -109,6 +113,7 @@
       (fill-in "Username" "dantheman")
       (fill-in "Password" "password")
       (fill-in "Confirm password" "password")
+      (fill-in-captcha)
       (press "Register")
       (has (status? 200))
       (within [:div.error :ul :li]
@@ -119,6 +124,7 @@
       (fill-in "Username" "dantheman")
       (fill-in "Password" "password")
       (fill-in "Confirm password" "password")
+      (fill-in-captcha)
       (press "Register")
       (has (status? 200))
       (within [:div.error :ul :li]
@@ -128,6 +134,7 @@
       (fill-in "Username" "")
       (fill-in "Password" "password")
       (fill-in "Confirm password" "password")
+      (fill-in-captcha)
       (press "Register")
       (has (status? 200))
       (within [:div.error :ul :li]
@@ -135,6 +142,7 @@
       (fill-in "Username" "<script>")
       (fill-in "Password" "password")
       (fill-in "Confirm password" "password")
+      (fill-in-captcha)
       (press "Register")
       (has (status? 200))
       (within [:div.error :ul :li]
@@ -143,10 +151,28 @@
       (fill-in "Username" "fixture")
       (fill-in "Password" "password")
       (fill-in "Confirm password" "password")
+      (fill-in-captcha)
       (press "Register")
       (has (status? 200))
       (within [:div.error :ul :li]
-        (has (text? "Username is already taken")))))
+        (has (text? "Username is already taken")))
+
+      (fill-in "Username" "fixture2")
+      (fill-in "Password" "password")
+      (fill-in "Confirm password" "password")
+      (fill-in-captcha "bad-value")
+      (press "Register")
+      (has (status? 200))
+      (within [:div.error :ul :li]
+        (has (text? "Captcha response is invalid.")))
+      (fill-in "Username" "fixture2")
+      (fill-in "Password" "password")
+      (fill-in "Confirm password" "password")
+      (fill-in-captcha "")
+      (press "Register")
+      (has (status? 200))
+      (within [:div.error :ul :li]
+        (has (text? "Captcha response is invalid.")))))
 
 (deftest user-can-update-info
   (email/expect-mock-emails 3)


### PR DESCRIPTION
### Allow overriding any CSP setting

### Add hcaptcha to signup form

This should help prevent automated spam signups.

Implements #628.