### PR TITLE
Fix status-message sending

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -76,6 +76,7 @@
   raven-clj/raven-clj {:mvn/version "1.7.0"}
   ring/ring-core {:mvn/version "1.12.1"}
   ring/ring-defaults {:mvn/version "0.5.0"}
+  ;; Audit clojars.ring-servlet-patch if updating this version!
   ring/ring-jetty-adapter {:mvn/version "1.12.1"}
   ring-jetty-component/ring-jetty-component {:mvn/version "0.3.1"}
   ring-middleware-format/ring-middleware-format {:mvn/version "0.7.5"}

--- a/src/clojars/ring_servlet_patch.clj
+++ b/src/clojars/ring_servlet_patch.clj
@@ -1,44 +1,53 @@
 (ns clojars.ring-servlet-patch
+  "The Maven deploy lib prints the HTTP status message on request failure, and is
+  the only mechanism we have to signal validation errors to clients.
+  Unfortunately, setting the status message is deprecated in the servlet spec,
+  so we have to jump through some hoops to set it.
+
+  This sets it by calling a deprecated method on Jetty's Response object, and we
+  monkey-patch ring-jetty-adapter to call this for us.
+
+  A prior implementation we tried should have been the \"correct\" way to do
+  this (using a Jetty HandlerWrapper), but it only worked intermittently for
+  unknown reasons (you can see that impl here:
+  https://github.com/clojars/clojars-web/blob/6368d3d9764a26e6f1ec2106de195325b898fc4c/src/clojars/ring_servlet_patch.clj).
+  Instead of doing more debugging of Jetty internals, we just opted to do this
+  directly in clojure with this hack."
+  (:require
+   [ring.core.protocols :as ring.protocols]
+   [ring.util.jakarta.servlet :as ring.servlet])
   (:import
    (jakarta.servlet.http
-    HttpServletResponse
-    HttpServletResponseWrapper)
+    HttpServletResponse)
    (org.eclipse.jetty.server
-    Response
-    Server)
-   (org.eclipse.jetty.server.handler
-    HandlerWrapper)
-   (org.eclipse.jetty.servlet
-    ServletContextHandler)))
+    Response)))
 
 (set! *warn-on-reflection* true)
 
-(defn response-wrapper
-  [^Response response]
-  (proxy [HttpServletResponseWrapper] [response]
-    (setHeader [name value]
-      (if (and (= "status-message" name) value)
-        ;; Jetty ignores the reason passed to HttpServletResponse#setStatus(),
-        ;; so we have to call a method on Jetty's response impl instead.
-        (.setStatusWithReason ^Response response (.getStatus response) value)
-        (.setHeader ^HttpServletResponse response name value)))))
+;; Copied from ring.util.jakarta.servlet (from ring/ring-jetty-adapter 1.12.1)
+;; and modified to set the status message on the response. This should be
+;; audited when we upgrade ring-jetty-adapter.
+(defn- update-servlet-response
+  "Update the HttpServletResponse using a response map. Takes an optional
+  AsyncContext."
+  ([response response-map]
+   (update-servlet-response response nil response-map))
+  ([^HttpServletResponse response context response-map]
+   (let [{:keys [status status-message headers body]} response-map]
+     (when (nil? response)
+       (throw (NullPointerException. "HttpServletResponse is nil")))
+     (when (nil? response-map)
+       (throw (NullPointerException. "Response map is nil")))
+     (when status
+       (if status-message
+         ;; Jetty ignores the reason passed to HttpServletResponse#setStatus(),
+         ;; so we have to call a method on Jetty's response impl instead.
+         (.setStatusWithReason ^Response response status status-message)
+         (.setStatus response status)))
+     (#'ring.servlet/set-headers response headers)
+     (let [output-stream (#'ring.servlet/make-output-stream response context)]
+       (ring.protocols/write-body-to-stream body response-map output-stream)))))
 
-(defn handler-wrapper
-  ^HandlerWrapper []
-  (proxy [HandlerWrapper] []
-    (handle [target base-request request response]
-      (let [response (response-wrapper response)
-            ;; This prevents reflection on the proxy-super call
-            ;; by hinting the explicit `this`.
-            ^HandlerWrapper this this]
-        (proxy-super handle target base-request request response)))))
-
-(defn use-status-message-header
-  "This adds a wrapper around the servlet handler to override .setHeader on the response.
-  We do this so we can set the status message of the response by smuggling it
-  through ring as a header, as this setting this is not exposed by ring.
-
-  The status message is used to provide additional context when deploying."
-  [^Server server]
-  (let [^ServletContextHandler handler (.getHandler server)]
-    (.insertHandler handler (handler-wrapper))))
+(defn monkey-patch-update-servlet-response-to-send-status-message
+  []
+  (alter-var-root #'ring.servlet/update-servlet-response (constantly update-servlet-response)))

--- a/src/clojars/routes/repo.clj
+++ b/src/clojars/routes/repo.clj
@@ -601,7 +601,7 @@
         (log/info {:tag :deploy-password-rejection
                    :username username})
         {:status 401
-         :headers {"status-message" (format "Unauthorized - %s" message)}}))))
+         :status-message (format "Unauthorized - %s" message)}))))
 
 (defn wrap-exceptions [app reporter]
   (fn [req]
@@ -613,5 +613,5 @@
           (report-error reporter e nil request-id)
           (let [data (ex-data e)]
             {:status (or (:status data) 403)
-             :headers {"status-message" (:status-message data)}
+             :status-message (:status-message data)
              :body (.getMessage e)}))))))

--- a/src/clojars/system.clj
+++ b/src/clojars/system.clj
@@ -69,6 +69,7 @@
 
 (defn new-system [config]
   (let [{:as config :keys [github-oauth gitlab-oauth]} config]
+    (patch/monkey-patch-update-servlet-response-to-send-status-message)
     (-> (merge
          (base-system config)
          (component/system-map
@@ -83,8 +84,7 @@
           :event-emitter  (event/new-sqs-emitter (:event-queue config))
           :event-receiver (event/new-sqs-receiver (:event-queue config))
           :hcaptcha       (hcaptcha/new-hcaptcha (:hcaptcha config))
-          :http           (jetty-server (assoc (:http config)
-                                               :configurator patch/use-status-message-header))
+          :http           (jetty-server (:http config))
           :http-client    (remote-service/new-http-remote-service)
           :mailer         (simple-mailer (:mail config))
           :notifications  (notifications/notification-component)


### PR DESCRIPTION
This removes the unreliable HandlerWrapper implementation for a more
straightforward monkeypatch of ring-jetty-adapter to achieve the same
thing.

Fixes #889.