### PR TITLE
Add some additional fields to the artifact API payload

### DIFF
--- a/dev-resources/test-0.0.3-SNAPSHOT/test.pom
+++ b/dev-resources/test-0.0.3-SNAPSHOT/test.pom
@@ -28,4 +28,19 @@
     <url>https://github.com/fake/test</url>
   </scm>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.pokustan</groupId>
+      <artifactId>pokure</artifactId>
+      <version>0.10.1</version>
+    </dependency>
+    <dependency>
+      <groupId>clj-jarjar</groupId>
+      <artifactId>clj-jarjar</artifactId>
+      <version>6.5.4</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+
 </project>

--- a/src/clojars/db.clj
+++ b/src/clojars/db.clj
@@ -1108,7 +1108,8 @@
   [db group-id artifact-id]
   (q db
      {:select [:j/jar_name :j/group_name :homepage :description
-               :user [:j/version :latest_version] [:r2/version :latest_release]]
+               :user [:j/version :latest_version] [:r2/version :latest_release]
+               :licenses]
       :from [[:jars :j]]
       ;; find the latest version
       :join [[{:select [:jar_name :group_name [[:max :created] :created]]
@@ -1158,6 +1159,12 @@
    (if artifact-id
      (find-jars-information* db group-id artifact-id)
      (find-groups-jars-information db group-id))))
+
+(defn find-jar-artifact
+  [db group-id artifact-id]
+  (some-> (find-jars-information db group-id artifact-id)
+          first
+          (update :licenses safe-edn-read str-map-vector)))
 
 (defn set-group-mfa-required
   [db group-id required?]

--- a/src/clojars/db.clj
+++ b/src/clojars/db.clj
@@ -1109,7 +1109,7 @@
   (q db
      {:select [:j/jar_name :j/group_name :homepage :description
                :user [:j/version :latest_version] [:r2/version :latest_release]
-               :licenses]
+               :licenses :scm]
       :from [[:jars :j]]
       ;; find the latest version
       :join [[{:select [:jar_name :group_name [[:max :created] :created]]
@@ -1164,7 +1164,8 @@
   [db group-id artifact-id]
   (some-> (find-jars-information db group-id artifact-id)
           first
-          (update :licenses safe-edn-read str-map-vector)))
+          (update :licenses safe-edn-read str-map-vector)
+          (update :scm safe-edn-read str-map)))
 
 (defn set-group-mfa-required
   [db group-id required?]

--- a/src/clojars/routes/api.clj
+++ b/src/clojars/routes/api.clj
@@ -11,7 +11,7 @@
    [ring.util.response :refer [response]]))
 
 (defn get-artifact [db stats group-id artifact-id]
-  (if-let [artifact (first (db/find-jars-information db group-id artifact-id))]
+  (if-let [artifact (db/find-jar-artifact db group-id artifact-id)]
     (-> artifact
         (assoc
          :recent_versions (db/recent-versions db group-id artifact-id)

--- a/src/clojars/routes/api.clj
+++ b/src/clojars/routes/api.clj
@@ -4,6 +4,8 @@
     [db :as db]
     [stats :as stats]
     [http-utils :refer [wrap-cors-headers]]]
+   [clojure
+    [set :as set]]
    [compojure
     [core :as compojure :refer [ANY context GET]]
     [route :refer [not-found]]]
@@ -22,6 +24,14 @@
                          (assoc version
                                 :downloads (stats/download-count stats group-id artifact-id (:version version))))
                        versions)))
+        (assoc :dependencies
+               (->> (db/find-dependencies db group-id artifact-id (:latest_version artifact))
+                    (map #(-> %
+                              (select-keys [:dep_group_name :dep_jar_name :dep_version :dep_scope])
+                              (set/rename-keys {:dep_group_name :group_name
+                                                :dep_jar_name   :jar_name
+                                                :dep_version    :version
+                                                :dep_scope      :scope})))))
         response)
     (not-found nil)))
 

--- a/test/clojars/integration/api_test.clj
+++ b/test/clojars/integration/api_test.clj
@@ -75,6 +75,8 @@
               :user "dantheman"
               :description "TEST"
               :homepage "http://example.com"
+              :licenses [{:name "Apache-2.0"
+                          :url "https://www.apache.org/licenses/LICENSE-2.0.txt"}]
               :downloads 0
               :recent_versions [{:downloads 0 :version "0.0.3-SNAPSHOT"}
                                 {:downloads 0 :version "0.0.2"}

--- a/test/clojars/integration/api_test.clj
+++ b/test/clojars/integration/api_test.clj
@@ -84,7 +84,15 @@
               :downloads 0
               :recent_versions [{:downloads 0 :version "0.0.3-SNAPSHOT"}
                                 {:downloads 0 :version "0.0.2"}
-                                {:downloads 0 :version "0.0.1"}]}
+                                {:downloads 0 :version "0.0.1"}]
+              :dependencies [{:group_name "org.pokustan",
+                              :jar_name "pokure",
+                              :version "0.10.1",
+                              :scope "compile"}
+                             {:group_name "clj-jarjar",
+                              :jar_name "clj-jarjar",
+                              :version "6.5.4",
+                              :scope "test"}]}
              body))))
 
   (testing "get non-existent artifact"

--- a/test/clojars/integration/api_test.clj
+++ b/test/clojars/integration/api_test.clj
@@ -77,6 +77,10 @@
               :homepage "http://example.com"
               :licenses [{:name "Apache-2.0"
                           :url "https://www.apache.org/licenses/LICENSE-2.0.txt"}]
+              :scm {:tag "70470ff6ae74505bdbfe5955fca6797f613c113c"
+                    :url "https://github.com/fake/test"
+                    :connection "scm:git:git://github.com/fake/test.git",
+                    :developer-connection "scm:git:ssh://git@github.com/fake/test.git"}
               :downloads 0
               :recent_versions [{:downloads 0 :version "0.0.3-SNAPSHOT"}
                                 {:downloads 0 :version "0.0.2"}


### PR DESCRIPTION
Adds the following:
- licenses: describes the licenses associated with the artifact
- scm: describes the location of source code of the artifact
- dependencies: lists the dependencies of the artifact
These fields are obtained directly from the POM file