### PR TITLE
[api] Add /api/release-feed

### DIFF
--- a/src/clojars/db/migrate.clj
+++ b/src/clojars/db/migrate.clj
@@ -135,6 +135,12 @@
    ["alter table permissions add scope text default '*' not null"
     "create index permissions_idx0 on permissions (group_name, scope)"]))
 
+;; This makes the release feed faster
+(defn- add-created-index-to-jars-table
+  [tx]
+  (db/do-commands tx
+                  ["create index jars_idx_created on jars (created)"]))
+
 (def migrations
   [#'initial-schema
    #'add-deploy-tokens-table
@@ -150,7 +156,8 @@
    #'add-indexes-to-deps-table
    #'add-group-settings-table
    #'rename-groups-to-permissions
-   #'add-scope-to-permissions])
+   #'add-scope-to-permissions
+   #'add-created-index-to-jars-table])
 
 (defn migrate [db]
   (db/do-commands db

--- a/src/clojars/routes/api.clj
+++ b/src/clojars/routes/api.clj
@@ -94,4 +94,5 @@
 (defn routes [db stats]
   (-> (handler db stats)
       (wrap-cors-headers)
-      (wrap-restful-response :formats [:json :edn :yaml :transit-json])))
+      (wrap-restful-response :formats [:json :edn :yaml :transit-json]
+                             :format-options {:json {:date-format "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"}})))

--- a/src/clojars/routes/api.clj
+++ b/src/clojars/routes/api.clj
@@ -1,16 +1,18 @@
 (ns clojars.routes.api
   (:require
-   [clojars
-    [db :as db]
-    [stats :as stats]
-    [http-utils :refer [wrap-cors-headers]]]
-   [clojure
-    [set :as set]]
-   [compojure
-    [core :as compojure :refer [ANY context GET]]
-    [route :refer [not-found]]]
+   [clojars.db :as db]
+   [clojars.http-utils :refer [wrap-cors-headers]]
+   [clojars.stats :as stats]
+   [clojure.set :as set]
+   [compojure.core :as compojure :refer [ANY context GET]]
+   [compojure.route :refer [not-found]]
    [ring.middleware.format-response :refer [wrap-restful-response]]
-   [ring.util.response :refer [response]]))
+   [ring.util.response :as ring.util])
+  (:import
+   (java.sql
+    Timestamp)
+   (java.time
+    ZonedDateTime)))
 
 (defn get-artifact [db stats group-id artifact-id]
   (if-let [artifact (db/find-jar-artifact db group-id artifact-id)]
@@ -32,27 +34,59 @@
                                                 :dep_jar_name   :jar_name
                                                 :dep_version    :version
                                                 :dep_scope      :scope})))))
-        response)
+        (ring.util/response))
     (not-found nil)))
+
+(defn- generate-release-response
+  [from-inst releases]
+  (let [next-inst (if (seq releases)
+                    (Timestamp/.toInstant (:created (last releases)))
+                    from-inst)]
+    {:next    (format "/api/release-feed?from=%s" next-inst)
+     :releases (mapv (fn [{:keys [created group_name jar_name version]}]
+                       {:artifact_id jar_name
+                        :group_id    group_name
+                        :released_at created
+                        :version     version})
+                     releases)}))
+
+;; public only for testing
+(def page-size 500)
+
+(defn- get-release-feed
+  [db from-str]
+  (if-some [from-inst (try
+                        (-> (ZonedDateTime/parse from-str)
+                            (.toInstant))
+                        (catch Exception _
+                          nil))]
+    (let [releases (db/version-feed db from-inst page-size)]
+      (ring.util/response
+       (generate-release-response from-inst releases)))
+    (ring.util/bad-request {:invalid {:from from-str}})))
 
 (defn handler [db stats]
   (compojure/routes
    (context "/api" []
-            (GET ["/groups/:group-id", :group-id #"[^/]+"] [group-id]
+            (GET ["/groups/:group-id" :group-id #"[^/]+"] [group-id]
                  (if-let [jars (seq (db/find-jars-information db group-id))]
-                   (response
+                   (ring.util/response
                     (map (fn [jar]
                            (assoc jar
                                   :downloads (stats/download-count stats group-id (:jar_name jar))))
                          jars))
                    (not-found nil)))
-            (GET ["/artifacts/:artifact-id", :artifact-id #"[^/]+"] [artifact-id]
+            (GET ["/artifacts/:artifact-id" :artifact-id #"[^/]+"] [artifact-id]
                  (get-artifact db stats artifact-id artifact-id))
-            (GET ["/artifacts/:group-id/:artifact-id", :group-id #"[^/]+", :artifact-id #"[^/]+"] [group-id artifact-id]
+            (GET ["/artifacts/:group-id/:artifact-id"
+                  :group-id #"[^/]+"
+                  :artifact-id #"[^/]+"] [group-id artifact-id]
                  (get-artifact db stats group-id artifact-id))
+            (GET ["/release-feed"] [from]
+                 (get-release-feed db from))
             (GET "/users/:username" [username]
                  (if-let [groups (seq (db/find-groupnames db username))]
-                   (response {:groups groups})
+                   (ring.util/response {:groups groups})
                    (not-found nil)))
             (ANY "*" _
                  (not-found nil)))))

--- a/src/clojars/search.clj
+++ b/src/clojars/search.clj
@@ -11,6 +11,8 @@
   (:import
    (java.nio.file
     Paths)
+   (java.time
+    ZonedDateTime)
    (java.util
     Date)
    (org.apache.lucene.analysis
@@ -279,7 +281,7 @@
 
 (defn date-in-epoch-ms
   [iso-8601-date-string]
-  (-> (java.time.ZonedDateTime/parse iso-8601-date-string)
+  (-> (ZonedDateTime/parse iso-8601-date-string)
       .toInstant
       .toEpochMilli
       str))

--- a/test/clojars/integration/api_test.clj
+++ b/test/clojars/integration/api_test.clj
@@ -127,9 +127,9 @@
     (is (= 400 (:status res)))
     (is (= {:invalid {:from "1"}} body))))
 
-(defn date-string?
+(defn date-string-with-ms?
   [s]
-  (re-matches #"\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ" s))
+  (re-matches #"\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\d\d\dZ" s))
 
 (deftest test-release-feed
   (let [start-time (System/currentTimeMillis)
@@ -161,19 +161,19 @@
               :releases
               [{:artifact_id "test"
                 :group_id "org.clojars.dantheman"
-                :released_at date-string?
+                :released_at date-string-with-ms?
                 :version "0.0.1"}
                {:artifact_id "test"
                 :group_id "org.clojars.dantheman"
-                :released_at date-string?
+                :released_at date-string-with-ms?
                 :version "0.0.2"}
                {:artifact_id "test"
                 :group_id "org.clojars.dantheman"
-                :released_at date-string?
+                :released_at date-string-with-ms?
                 :version "0.0.3-SNAPSHOT"}
                {:artifact_id "test"
                 :group_id "org.clojars.dantheman"
-                :released_at date-string?
+                :released_at date-string-with-ms?
                 :version "0.0.3-SNAPSHOT"}]}
              body))
 
@@ -201,11 +201,11 @@
                 :releases
                 [{:artifact_id "test"
                   :group_id "org.clojars.dantheman"
-                  :released_at date-string?
+                  :released_at date-string-with-ms?
                   :version "0.0.1"}
                  {:artifact_id "test"
                   :group_id "org.clojars.dantheman"
-                  :released_at date-string?
+                  :released_at date-string-with-ms?
                   :version "0.0.2"}]}
                body1))
 
@@ -214,11 +214,11 @@
                 :releases
                 [{:artifact_id "test"
                   :group_id "org.clojars.dantheman"
-                  :released_at date-string?
+                  :released_at date-string-with-ms?
                   :version "0.0.3-SNAPSHOT"}
                  {:artifact_id "test"
                   :group_id "org.clojars.dantheman"
-                  :released_at date-string?
+                  :released_at date-string-with-ms?
                   :version "0.0.3-SNAPSHOT"}]}
                body2))
 
@@ -261,7 +261,7 @@
                 :releases
                 [{:artifact_id "test"
                   :group_id "org.clojars.dantheman"
-                  :released_at date-string?
+                  :released_at date-string-with-ms?
                   :version "0.0.1"}]}
                body1))
 
@@ -271,11 +271,11 @@
                 :releases
                 [{:artifact_id "test"
                   :group_id "org.clojars.dantheman"
-                  :released_at date-string?
+                  :released_at date-string-with-ms?
                   :version "0.0.2"}
                  {:artifact_id "test"
                   :group_id "org.clojars.dantheman"
-                  :released_at date-string?
+                  :released_at date-string-with-ms?
                   :version "0.0.3-SNAPSHOT"}]}
                body2))
 
@@ -285,7 +285,7 @@
                 :releases
                 [{:artifact_id "test"
                   :group_id "org.clojars.dantheman"
-                  :released_at date-string?
+                  :released_at date-string-with-ms?
                   :version "0.0.3-SNAPSHOT"}]}
                body3))
 

--- a/test/clojars/integration/api_test.clj
+++ b/test/clojars/integration/api_test.clj
@@ -2,21 +2,34 @@
   (:require
    [cheshire.core :as json]
    [clj-http.client :as client]
+   [clojars.db :as db]
    [clojars.integration.steps :refer [register-as inject-artifacts-into-repo!]]
+   [clojars.routes.api :as api]
    [clojars.test-helper :as help]
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing use-fixtures]]
-   [kerodon.core :refer [session]]))
+   [kerodon.core :refer [session]]
+   [matcher-combinators.test])
+  (:import
+   (java.sql
+    Timestamp)
+   (java.time
+    Instant)))
 
 (use-fixtures :each
   help/default-fixture
   help/with-clean-database
   help/run-test-app)
 
+(defn get-api*
+  ([url-fragment]
+   (get-api* url-fragment nil))
+  ([url-fragment opts]
+   (-> (str "http://localhost:" help/test-port url-fragment)
+       (client/get opts))))
+
 (defn get-api [parts & [opts]]
-  (-> (str "http://localhost:" help/test-port "/api/"
-           (str/join "/" (map name parts)))
-      (client/get opts)))
+  (get-api* (str "/api/" (str/join "/" (map name parts))) opts))
 
 (defn assert-404 [& get-args]
   (try
@@ -107,3 +120,176 @@
 
   (testing "get non-existent user"
     (assert-404 [:users "danethemane"])))
+
+(deftest test-release-feed-with-invalid-date
+  (let [res (get-api* "/api/release-feed?from=1" {:throw-exceptions? false})
+        body (json/parse-string (:body res) true)]
+    (is (= 400 (:status res)))
+    (is (= {:invalid {:from "1"}} body))))
+
+(defn date-string?
+  [s]
+  (re-matches #"\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ" s))
+
+(deftest test-release-feed
+  (let [start-time (System/currentTimeMillis)
+        start-inst (Instant/ofEpochMilli start-time)
+        curr-time (atom start-time)
+        db (get-in help/system [:db :spec])]
+    (with-redefs [db/get-time (fn []
+                                (Timestamp. (swap! curr-time inc)))]
+      (-> (session (help/app))
+          (register-as "dantheman" "test@example.org" "password"))
+      (inject-artifacts-into-repo! db "dantheman" "test.jar" "test-0.0.1/test.pom")
+      (inject-artifacts-into-repo! db "dantheman" "test.jar" "test-0.0.2/test.pom")
+      (inject-artifacts-into-repo! db "dantheman" "test.jar" "test-0.0.3-SNAPSHOT/test.pom")
+      (inject-artifacts-into-repo! db "dantheman" "test.jar" "test-0.0.3-SNAPSHOT/test.pom"))
+
+    (testing "Every supported content-type works"
+      (doseq [f ["application/json" "application/edn" "application/x-yaml" "application/transit+json"]]
+        (testing f
+          (let [res (get-api* (format "/api/release-feed?from=%s" start-inst)
+                              {:accept f})]
+            (is (= f (help/get-content-type res)))
+            (is (= 200 (:status res)))))))
+
+    (testing "The correct releases are returned, along with the correct new from value"
+      (let [res (get-api* (format "/api/release-feed?from=%s" (Instant/ofEpochMilli start-time)))
+            body (json/parse-string (:body res) true)]
+        (is (match?
+             {:next (format "/api/release-feed?from=%s" (Instant/ofEpochMilli @curr-time))
+              :releases
+              [{:artifact_id "test"
+                :group_id "org.clojars.dantheman"
+                :released_at date-string?
+                :version "0.0.1"}
+               {:artifact_id "test"
+                :group_id "org.clojars.dantheman"
+                :released_at date-string?
+                :version "0.0.2"}
+               {:artifact_id "test"
+                :group_id "org.clojars.dantheman"
+                :released_at date-string?
+                :version "0.0.3-SNAPSHOT"}
+               {:artifact_id "test"
+                :group_id "org.clojars.dantheman"
+                :released_at date-string?
+                :version "0.0.3-SNAPSHOT"}]}
+             body))
+
+        (is (= (sort-by :released_at (:releases body))
+               (:releases body)))))
+
+    (testing "getting the next page returns an empty page, along with the from value we gave"
+      (let [res (get-api* (format "/api/release-feed?from=%s" (Instant/ofEpochMilli @curr-time)))
+            body (json/parse-string (:body res) true)]
+        (is (match?
+             {:next (format "/api/release-feed?from=%s" (Instant/ofEpochMilli @curr-time))
+              :releases []}
+             body))))
+
+    (testing "results up to the page size are returned, and the next page has more results"
+      (with-redefs [api/page-size 2]
+        (let [res1 (get-api* (format "/api/release-feed?from=%s" (Instant/ofEpochMilli start-time)))
+              body1 (json/parse-string (:body res1) true)
+              res2 (get-api* (:next body1))
+              body2 (json/parse-string (:body res2) true)
+              res3 (get-api* (:next body2))
+              body3 (json/parse-string (:body res3) true)]
+          (is (match?
+               {:next (format "/api/release-feed?from=%s" (Instant/ofEpochMilli (+ start-time 3)))
+                :releases
+                [{:artifact_id "test"
+                  :group_id "org.clojars.dantheman"
+                  :released_at date-string?
+                  :version "0.0.1"}
+                 {:artifact_id "test"
+                  :group_id "org.clojars.dantheman"
+                  :released_at date-string?
+                  :version "0.0.2"}]}
+               body1))
+
+          (is (match?
+               {:next (format "/api/release-feed?from=%s" (Instant/ofEpochMilli @curr-time))
+                :releases
+                [{:artifact_id "test"
+                  :group_id "org.clojars.dantheman"
+                  :released_at date-string?
+                  :version "0.0.3-SNAPSHOT"}
+                 {:artifact_id "test"
+                  :group_id "org.clojars.dantheman"
+                  :released_at date-string?
+                  :version "0.0.3-SNAPSHOT"}]}
+               body2))
+
+          (is (match?
+               {:next (format "/api/release-feed?from=%s" (Instant/ofEpochMilli @curr-time))
+                :releases []}
+               body3)))))))
+
+(deftest test-release-feed-with-same-ms-at-page-boundary
+  (let [start-time (System/currentTimeMillis)
+        curr-time (atom start-time)
+        db (get-in help/system [:db :spec])]
+    (with-redefs [db/get-time (fn []
+                                (Timestamp. @curr-time))]
+      (-> (session (help/app))
+          (register-as "dantheman" "test@example.org" "password"))
+      ;; Given: four artifacts, two of which were released in the same ms
+      (swap! curr-time inc)
+      (inject-artifacts-into-repo! db "dantheman" "test.jar" "test-0.0.1/test.pom")
+      (swap! curr-time inc)
+      (inject-artifacts-into-repo! db "dantheman" "test.jar" "test-0.0.2/test.pom")
+      (inject-artifacts-into-repo! db "dantheman" "test.jar" "test-0.0.3-SNAPSHOT/test.pom")
+      (swap! curr-time inc)
+      (inject-artifacts-into-repo! db "dantheman" "test.jar" "test-0.0.3-SNAPSHOT/test.pom"))
+
+    (testing "When the page boundary is between the two releases in the same ms"
+      (with-redefs [api/page-size 2]
+        (let [res1 (get-api* (format "/api/release-feed?from=%s" (Instant/ofEpochMilli start-time)))
+              body1 (json/parse-string (:body res1) true)
+              res2 (get-api* (:next body1))
+              body2 (json/parse-string (:body res2) true)
+              res3 (get-api* (:next body2))
+              body3 (json/parse-string (:body res3) true)
+              res4 (get-api* (:next body3))
+              body4 (json/parse-string (:body res4) true)]
+
+          ;; Then: we only get the first release on the first page
+          (is (match?
+               {:next (format "/api/release-feed?from=%s" (Instant/ofEpochMilli (inc start-time)))
+                :releases
+                [{:artifact_id "test"
+                  :group_id "org.clojars.dantheman"
+                  :released_at date-string?
+                  :version "0.0.1"}]}
+               body1))
+
+          ;; And: the rest of the former page is part of this one
+          (is (match?
+               {:next (format "/api/release-feed?from=%s" (Instant/ofEpochMilli (+ start-time 2)))
+                :releases
+                [{:artifact_id "test"
+                  :group_id "org.clojars.dantheman"
+                  :released_at date-string?
+                  :version "0.0.2"}
+                 {:artifact_id "test"
+                  :group_id "org.clojars.dantheman"
+                  :released_at date-string?
+                  :version "0.0.3-SNAPSHOT"}]}
+               body2))
+
+          ;; And: paging is correct for the rest of the pages
+          (is (match?
+               {:next (format "/api/release-feed?from=%s" (Instant/ofEpochMilli (+ start-time 3)))
+                :releases
+                [{:artifact_id "test"
+                  :group_id "org.clojars.dantheman"
+                  :released_at date-string?
+                  :version "0.0.3-SNAPSHOT"}]}
+               body3))
+
+          (is (match?
+               {:next (format "/api/release-feed?from=%s" (Instant/ofEpochMilli @curr-time))
+                :releases []}
+               body4)))))))


### PR DESCRIPTION
### Import java class

This is just to match the style we try to use.

### [api] Add /api/release-feed

This provides an api to get all releases since a certain date, in pages
of 500.

### Add index on jars.created

This improves the performance of the releases api endpoint, as it only
queries by created.

This implements #894.

