### PR TITLE
Improve user validations  

### DIFF
--- a/src/clojars/friend/registration.clj
+++ b/src/clojars/friend/registration.clj
@@ -5,8 +5,8 @@
    [clojars.hcaptcha :as hcaptcha]
    [clojars.http-utils :as http-utils]
    [clojars.log :as log]
-   [clojars.web.user :refer [register-form new-user-validations normalize-email]]
-   [valip.core :refer [validate]]))
+   [clojars.user-validations :as uv]
+   [clojars.web.user :refer [register-form normalize-email]]))
 
 (defn register
   [db hcaptcha {:keys [confirm email h-captcha-response password username]}]
@@ -14,11 +14,11 @@
     (log/with-context {:email email
                        :username username
                        :tag :registration}
-      (if-let [errors (apply validate {:captcha  h-captcha-response
-                                       :email    email
-                                       :password password
-                                       :username username}
-                             (new-user-validations db hcaptcha confirm))]
+      (if-let [errors (uv/validate {:captcha  h-captcha-response
+                                    :email    email
+                                    :password password
+                                    :username username}
+                                   (uv/new-user-validations db hcaptcha confirm))]
         (do
           (log/info {:status :validation-failed})
           (http-utils/with-extra-csp-srcs

--- a/src/clojars/hcaptcha.clj
+++ b/src/clojars/hcaptcha.clj
@@ -61,3 +61,7 @@
   [config]
   (map->Hcaptcha {:config config
                   :client (remote-service/new-http-remote-service)}))
+
+(defn new-mock-hcaptcha
+  []
+  {:client (remote-service/new-mock-remote-service)})

--- a/src/clojars/hcaptcha.clj
+++ b/src/clojars/hcaptcha.clj
@@ -39,7 +39,7 @@
     "missing-input-secret"
     "sitekey-secret-mismatch"})
 
-(defn- log-and-maybe-thrpw
+(defn- log-and-maybe-throw
   [{:as _response :keys [error-codes success]}]
   (let [log-data {:tag :hcaptcha-response
                   :error-codes error-codes
@@ -54,7 +54,7 @@
                                               (site-key hcaptcha)
                                               (secret hcaptcha)
                                               hcaptcha-response)]
-    (log-and-maybe-thrpw response)
+    (log-and-maybe-throw response)
     (:success response)))
 
 (defn new-hcaptcha

--- a/src/clojars/user_validations.clj
+++ b/src/clojars/user_validations.clj
@@ -9,21 +9,9 @@
 
 (defn password-validations
   [confirm]
-  [[:password #(<= 8 (count %)) "Password must be 8 characters or longer"]
+  [[:password (pred/min-length 8) "Password must be 8 characters or longer"]
    [:password #(= % confirm) "Password and confirm password must match"]
-   [:password #(> 256 (count %)) "Password must be 256 or fewer characters"]])
-
-(def ^:private email-regex
-  (re-pattern (str "(?i)[a-z0-9!#$%&'*+/=?^_`{|}~-]+"
-                   "(?:\\.[a-z0-9!#$%&'*+/=?" "^_`{|}~-]+)*"
-                   "@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+"
-                   "[a-z0-9](?:[a-z0-9-]*[a-z0-9])?")))
-
-(defn- validate-email
-  [email]
-  (and (string? email)
-       (<= (.length ^String email) 254)
-       (some? (re-matches email-regex email))))
+   [:password (pred/max-length 256) "Password must be 256 or fewer characters"]])
 
 (defn user-validations
   ([db]
@@ -35,9 +23,10 @@
                                     (= existing-username (:user existing-user))))
                              #(nil? (db/find-user-by-user-or-email db %)))]
      [[:email pred/present? "Email can't be blank"]
-      [:email validate-email "Email is not valid"]
+      [:email pred/email-address? "Email is not valid"]
+      [:email (pred/max-length 256) "Email must be 256 or fewer characters"]
       [:email existing-email-fn "A user already exists with this email"]
-      [:username #(re-matches #"[a-z0-9_-]+" %)
+      [:username (pred/matches #"[a-z0-9_-]+")
        (str "Username must consist only of lowercase "
             "letters, numbers, hyphens and underscores.")]
       [:username pred/present? "Username can't be blank"]])))

--- a/src/clojars/user_validations.clj
+++ b/src/clojars/user_validations.clj
@@ -1,0 +1,80 @@
+(ns clojars.user-validations
+  (:require
+   [cemerick.friend.credentials :as creds]
+   [clojars.db :as db]
+   [clojars.hcaptcha :as hcaptcha]
+   [clojure.string :as str]
+   [valip.core :as valip]
+   [valip.predicates :as pred]))
+
+(defn password-validations
+  [confirm]
+  [[:password #(<= 8 (count %)) "Password must be 8 characters or longer"]
+   [:password #(= % confirm) "Password and confirm password must match"]
+   [:password #(> 256 (count %)) "Password must be 256 or fewer characters"]])
+
+(def ^:private email-regex
+  (re-pattern (str "(?i)[a-z0-9!#$%&'*+/=?^_`{|}~-]+"
+                   "(?:\\.[a-z0-9!#$%&'*+/=?" "^_`{|}~-]+)*"
+                   "@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+"
+                   "[a-z0-9](?:[a-z0-9-]*[a-z0-9])?")))
+
+(defn- validate-email
+  [email]
+  (and (string? email)
+       (<= (.length ^String email) 254)
+       (some? (re-matches email-regex email))))
+
+(defn user-validations
+  ([db]
+   (user-validations db nil))
+  ([db existing-username]
+   (let [existing-email-fn (if existing-username
+                             #(let [existing-user (db/find-user-by-user-or-email db %)]
+                                (or (nil? existing-user)
+                                    (= existing-username (:user existing-user))))
+                             #(nil? (db/find-user-by-user-or-email db %)))]
+     [[:email pred/present? "Email can't be blank"]
+      [:email validate-email "Email is not valid"]
+      [:email existing-email-fn "A user already exists with this email"]
+      [:username #(re-matches #"[a-z0-9_-]+" %)
+       (str "Username must consist only of lowercase "
+            "letters, numbers, hyphens and underscores.")]
+      [:username pred/present? "Username can't be blank"]])))
+
+(defn- captcha-validations
+  [hcaptcha]
+  [[:captcha (partial hcaptcha/valid-response? hcaptcha) "Captcha response is invalid."]])
+
+(defn new-user-validations
+  [db hcaptcha confirm]
+  (concat [[:password pred/present? "Password can't be blank"]
+           [:username #(not (or (db/reserved-names %)
+                                (db/find-user db %)
+                                (seq (db/group-activenames db %))))
+            "Username is already taken"]]
+          (user-validations db)
+          (password-validations confirm)
+          (captcha-validations hcaptcha)))
+
+(defn reset-password-validations
+  [db confirm]
+  (concat
+   [[:reset-code pred/present? "Reset code can't be blank."]
+    [:reset-code #(or (str/blank? %) (db/find-user-by-password-reset-code db %)) "The reset code does not exist or it has expired."]]
+   (password-validations confirm)))
+
+(defn- correct-password?
+  [db username current-password]
+  (let [user (db/find-user db username)]
+    (when (and user (not (str/blank? current-password)))
+      (creds/bcrypt-verify current-password (:password user)))))
+
+(defn current-password-validations
+  [db username]
+  [[:current-password pred/present? "Current password can't be blank"]
+   [:current-password #(correct-password? db username %) "Current password is incorrect"]])
+
+(defn validate
+  [data validations]
+  (apply valip/validate data validations))

--- a/test/clojars/integration/users_test.clj
+++ b/test/clojars/integration/users_test.clj
@@ -128,7 +128,7 @@
       (press "Register")
       (has (status? 200))
       (within [:div.error :ul :li]
-        (has (text? "Email is not valid")))
+        (has (text? "Email must be 256 or fewer characters")))
 
       (fill-in "Email" "test@example.org")
       (fill-in "Username" "")

--- a/test/clojars/unit/user_valudations_test.clj
+++ b/test/clojars/unit/user_valudations_test.clj
@@ -1,0 +1,141 @@
+(ns clojars.unit.user-valudations-test
+  (:require
+   [clojars.db :as db]
+   [clojars.hcaptcha :as hcaptcha]
+   [clojars.remote-service :as remote-service]
+   [clojars.test-helper :as help]
+   [clojars.user-validations :as uv]
+   [clojure.test :refer [is deftest use-fixtures]]
+   [matcher-combinators.test]))
+
+(use-fixtures :each
+  help/with-clean-database)
+
+(deftest test-password-validations
+  (is (nil? (uv/validate {:password "abcdefgh"} (uv/password-validations "abcdefgh"))))
+  (is (match?
+       {:password ["Password must be 8 characters or longer"]}
+       (uv/validate {:password "a"} (uv/password-validations "a"))))
+  (is (match?
+       {:password ["Password must be 8 characters or longer"
+                   "Password and confirm password must match"]}
+       (uv/validate {:password "a"} (uv/password-validations "b"))))
+  (let [long-password (apply str (repeat 257 "a"))]
+    (is (match?
+         {:password ["Password must be 256 or fewer characters"]}
+         (uv/validate {:password long-password} (uv/password-validations long-password))))))
+
+(deftest test-user-validations
+  (is (nil? (uv/validate {:email "foo@example.com"
+                          :username "auser"}
+                         (uv/user-validations help/*db*))))
+  (db/add-user help/*db* "foo@example.com" "auser" "password1")
+  (is (match?
+       {:email ["A user already exists with this email"]}
+       (uv/validate {:email "foo@example.com"
+                     :username "auser"}
+                    (uv/user-validations help/*db*))))
+  (is (nil?
+       (uv/validate {:email "foo@example.com"
+                     :username "auser"}
+                    (uv/user-validations help/*db* "auser"))))
+  (is (match?
+       {:email ["Email can't be blank"
+                "Email is not valid"]
+        :username ["Username must consist only of lowercase letters, numbers, hyphens and underscores."
+                   "Username can't be blank"]}
+       (uv/validate {:email ""
+                     :username ""}
+                    (uv/user-validations help/*db*))))
+  (is (match?
+       {:email ["Email is not valid"]
+        :username ["Username must consist only of lowercase letters, numbers, hyphens and underscores."]}
+       (uv/validate {:email "foo@@"
+                     :username "a User"}
+                    (uv/user-validations help/*db*)))))
+
+(deftest test-new-user-validations
+  (remote-service/with-mocking
+    (let [hcaptcha-service (hcaptcha/new-mock-hcaptcha)]
+      (remote-service/set-responder '-validate-hcaptcha-response
+                                    (fn [request-info]
+                                      {:success (= "valid" (get-in request-info [:form-params :response]))}))
+      (is (nil?
+           (uv/validate {:email "foo@example.com"
+                         :password "password1"
+                         :username "auser"
+                         :captcha "valid"}
+                        (uv/new-user-validations help/*db*  hcaptcha-service "password1"))))
+      (is (match?
+           {:captcha ["Captcha response is invalid."]}
+           (uv/validate {:email "foo@example.com"
+                         :password "password1"
+                         :username "auser"
+                         :captcha "invalid"}
+                        (uv/new-user-validations help/*db*  hcaptcha-service "password1"))))
+      (is (match?
+           {:password ["Password can't be blank"
+                       "Password must be 8 characters or longer"
+                       "Password and confirm password must match"]}
+           (uv/validate {:email "foo@example.com"
+                         :password ""
+                         :username "auser"
+                         :captcha "valid"}
+                        (uv/new-user-validations help/*db*  hcaptcha-service "password1"))))
+      (db/add-user help/*db* "foo@example.com" "auser" "password1")
+      (is (match?
+           {:username ["Username is already taken"]
+            :email ["A user already exists with this email"]}
+           (uv/validate {:email "foo@example.com"
+                         :password "password1"
+                         :username "auser"
+                         :captcha "valid"}
+                        (uv/new-user-validations help/*db*  hcaptcha-service "password1"))))
+      (is (match?
+           {:username ["Username is already taken"]}
+           (uv/validate {:email "foo2@example.com"
+                         :password "password1"
+                         :username "admin"
+                         :captcha "valid"}
+                        (uv/new-user-validations help/*db*  hcaptcha-service "password1"))))
+      (db/add-group help/*db* "auser" "agroup")
+      (is (match?
+           {:username ["Username is already taken"]}
+           (uv/validate {:email "foo2@example.com"
+                         :password "password1"
+                         :username "agroup"
+                         :captcha "valid"}
+                        (uv/new-user-validations help/*db*  hcaptcha-service "password1")))))))
+
+(deftest test-reset-password-validations
+  (db/add-user help/*db* "foo@example.com" "auser" "password1")
+  (let [reset-code (db/set-password-reset-code! help/*db* "auser")]
+    (is (nil?
+         (uv/validate {:reset-code reset-code
+                       :password "password1"}
+                      (uv/reset-password-validations help/*db* "password1"))))
+    (is (match?
+         {:reset-code ["Reset code can't be blank."]}
+         (uv/validate {:reset-code ""
+                       :password "password1"}
+                      (uv/reset-password-validations help/*db* "password1"))))
+    (is (match?
+         {:reset-code ["The reset code does not exist or it has expired."]}
+         (uv/validate {:reset-code "foo"
+                       :password "password1"}
+                      (uv/reset-password-validations help/*db* "password1"))))))
+
+(deftest current-password-validations
+  (db/add-user help/*db* "foo@example.com" "auser" "password1")
+  (is (nil?
+       (uv/validate {:current-password "password1"}
+                    (uv/current-password-validations help/*db* "auser"))))
+  (is (match?
+       {:current-password ["Current password can't be blank"
+                           "Current password is incorrect"]}
+       (uv/validate {:current-password ""}
+                    (uv/current-password-validations help/*db* "auser"))))
+  (is (match?
+       {:current-password ["Current password is incorrect"]}
+       (uv/validate {:current-password "wrong"}
+                    (uv/current-password-validations help/*db* "auser")))))

--- a/test/clojars/unit/user_valudations_test.clj
+++ b/test/clojars/unit/user_valudations_test.clj
@@ -57,6 +57,13 @@
        {:email ["Email must be 256 or fewer characters"]}
        (uv/validate {:email (format "foo@%s.com" (apply str (repeat 254 "a")))
                      :username "auser2"}
+                    (uv/user-validations help/*db*))))
+  ;; Tests that we protect against fuzzing on the registration form
+  (is (match?
+       {:email ["Invalid input"]}
+       ;; This string isn't valid UTF, so will cause postgres to throw
+       (uv/validate {:email (String. (byte-array [0x00]))
+                     :username "auser2"}
                     (uv/user-validations help/*db*)))))
 
 (deftest test-new-user-validations

--- a/test/clojars/unit/user_valudations_test.clj
+++ b/test/clojars/unit/user_valudations_test.clj
@@ -52,6 +52,11 @@
         :username ["Username must consist only of lowercase letters, numbers, hyphens and underscores."]}
        (uv/validate {:email "foo@@"
                      :username "a User"}
+                    (uv/user-validations help/*db*))))
+  (is (match?
+       {:email ["Email must be 256 or fewer characters"]}
+       (uv/validate {:email (format "foo@%s.com" (apply str (repeat 254 "a")))
+                     :username "auser2"}
                     (uv/user-validations help/*db*)))))
 
 (deftest test-new-user-validations


### PR DESCRIPTION
### Fix typo

### Move validations out to own ns w/tests

These were already tested with integration tests, but unit tests make it
easier to iterate on some small improvements.

### Use existing valip predicates

We had custom predicates that were already provided by valip.

This also moves email length validation out to its own validator.

### Handle exceptions in validation

If we get invalid input that triggers an exception in a validation
predicate, we will now show "Invalid input" instead of returning a 500.
