### PR TITLE
Use deps to infer more accurate linting

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,6 +1,7 @@
 {:lint-as
  {clojars.remote-service/defendpoint    clojure.core/defn
-  clojure.java.jdbc/with-db-transaction clojure.core/let}
+  clojure.java.jdbc/with-db-transaction clojure.core/let
+  next.jdbc.types/as-other              clojure.core/constantly}
 
  :linters
  {
@@ -18,6 +19,12 @@
              next.jdbc.sql        sql
              next.jdbc.types      jdbc.types}}
 
+  ;; TODO https://github.com/clojars/clojars-web/issues/904
+  :deprecated-var {:exclude {buddy.core.codecs.base64/decode {:namespaces [clojars.routes.token-breach]}
+                             buddy.core.codecs.base64/encode {:namespaces [clojars.web.user
+                                                                           clojars.unit.web.token-breach-test
+                                                                           clojars.integration.uploads-test]}}}
+
   :equals-expected-position {:level :warning}
 
   ;; use false?/true? instead of = false/true
@@ -30,4 +37,9 @@
   :single-key-in {:level :warning}
 
   :unresolved-symbol
-  {:exclude [(clojure.test/is [match?])]}}}
+  {:exclude [(clojure.test/is [match?])]}
+
+  :unresolved-var
+  {:exclude [digest/md5
+             digest/sha-1
+             next.jdbc.types/as-other]}}}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -36,9 +36,6 @@
   ;; warn if assoc-in/get-in/update-in are used with a single key
   :single-key-in {:level :warning}
 
-  :unresolved-symbol
-  {:exclude [(clojure.test/is [match?])]}
-
   :unresolved-var
   {:exclude [digest/md5
              digest/sha-1

--- a/.clj-kondo/imports/hiccup/hiccup/config.edn
+++ b/.clj-kondo/imports/hiccup/hiccup/config.edn
@@ -1,0 +1,2 @@
+{:lint-as {hiccup.def/defhtml clojure.core/defn}
+ :hooks {:analyze-call {hiccup.def/defelem hiccup.hooks/defelem}}}

--- a/.clj-kondo/imports/hiccup/hiccup/hiccup/hooks.clj
+++ b/.clj-kondo/imports/hiccup/hiccup/hiccup/hooks.clj
@@ -1,0 +1,38 @@
+(ns hiccup.hooks
+  (:require [clj-kondo.hooks-api :as api]
+            [clojure.set :as set]))
+
+;; See https://github.com/clj-kondo/clj-kondo/blob/master/doc/hooks.md
+
+(defn- parse-defn [elems]
+  (let [[fhead fbody] (split-with #(not (or (api/vector-node? %)
+                                            (api/list-node? %)))
+                                  elems)
+        arities (if (api/vector-node? (first fbody))
+                  (list (api/list-node fbody))
+                  fbody)]
+    [fhead arities]))
+
+(defn- count-args [arity]
+  (let [args (first (api/sexpr arity))]
+    (if (= '& (fnext (reverse args)))
+      true ; unbounded args
+      (count args))))
+
+(defn- dummy-arity [arg-count]
+  (api/list-node
+   (list
+    (api/vector-node
+     (vec (repeat arg-count (api/token-node '_)))))))
+
+(defn defelem [{:keys [node]}]
+  (let [[_ & rest] (:children node)
+        [fhead arities] (parse-defn rest)
+        arg-counts (set (filter number? (map count-args arities)))
+        dummy-arg-counts (set/difference (set (map inc arg-counts)) arg-counts)
+        dummy-arities (for [n dummy-arg-counts] (dummy-arity n))]
+    {:node
+     (api/list-node
+      (list*
+       (api/token-node 'clojure.core/defn)
+       (concat fhead arities dummy-arities)))}))

--- a/.clj-kondo/imports/kerodon/kerodon/config.edn
+++ b/.clj-kondo/imports/kerodon/kerodon/config.edn
@@ -1,0 +1,1 @@
+{:hooks {:macroexpand {kerodon.core/within kerodon.core/within}}}

--- a/.clj-kondo/imports/kerodon/kerodon/kerodon/core.clj
+++ b/.clj-kondo/imports/kerodon/kerodon/kerodon/core.clj
@@ -1,0 +1,4 @@
+(ns kerodon.core)
+
+(defmacro within [state selector & fns]
+  `(-> (let [_# ~selector] ~state) ~@fns))

--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,9 @@ pom.xml
 
 .clj-kondo/*
 !.clj-kondo/config.edn
+# TODO remove when upgrading to hiccup 2.x
+!.clj-kondo/imports/hiccup
+# TODO push unstream
+!.clj-kondo/imports/kerodon
 bin/.cache
 .cpcache

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ pom.xml
 !.clj-kondo/config.edn
 # TODO remove when upgrading to hiccup 2.x
 !.clj-kondo/imports/hiccup
-# TODO push unstream
+# TODO push upstream
 !.clj-kondo/imports/kerodon
 bin/.cache
 .cpcache

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ check:
 
 .PHONY: lint
 lint:
-	./bin/clj-kondo --lint src test
+	./bin/lint
 
 .PHONY: migrate-db
 migrate-db:

--- a/bin/clj-kondo
+++ b/bin/clj-kondo
@@ -47,6 +47,6 @@ ensure_clj_kondo
 CLJ_KONDO="${ROOT}/bin/.cache/clj-kondo-${VERSION}/clj-kondo"
 CLJ_PATH="$(clojure -A:dev -Spath)"
 
-${CLJ_KONDO} --lint "$(clojure -A:dev -Spath)" --skip-lint --copy-configs
-${CLJ_KONDO} --lint "$(clojure -A:dev -Spath)" --dependencies --parallel
-exec ${CLJ_KONDO} "$@"
+"${CLJ_KONDO}" --lint "${CLJ_PATH}" --skip-lint --copy-configs
+"${CLJ_KONDO}" --lint "${CLJ_PATH}" --dependencies --parallel
+exec "${CLJ_KONDO}" "$@"

--- a/bin/clj-kondo
+++ b/bin/clj-kondo
@@ -44,6 +44,9 @@ function ensure_clj_kondo() {
 
 ensure_clj_kondo
 
-${ROOT}/bin/.cache/clj-kondo-${VERSION}/clj-kondo --lint "$(clojure -A:dev -Spath)" --skip-lint --copy-configs
-${ROOT}/bin/.cache/clj-kondo-${VERSION}/clj-kondo --lint "$(clojure -A:dev -Spath)" --dependencies --parallel
-exec "${ROOT}/bin/.cache/clj-kondo-${VERSION}/clj-kondo" "$@"
+CLJ_KONDO="${ROOT}/bin/.cache/clj-kondo-${VERSION}/clj-kondo"
+CLJ_PATH="$(clojure -A:dev -Spath)"
+
+${CLJ_KONDO} --lint "$(clojure -A:dev -Spath)" --skip-lint --copy-configs
+${CLJ_KONDO} --lint "$(clojure -A:dev -Spath)" --dependencies --parallel
+exec ${CLJ_KONDO} "$@"

--- a/bin/clj-kondo
+++ b/bin/clj-kondo
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-CLJ_KONDO_VERSION="2025.04.07"
+CLJ_KONDO_VERSION="2025.06.05"
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)
 
 function ensure_clj_kondo() {
@@ -43,4 +43,7 @@ function ensure_clj_kondo() {
 }
 
 ensure_clj_kondo
+
+${ROOT}/bin/.cache/clj-kondo-${VERSION}/clj-kondo --lint "$(clojure -A:dev -Spath)" --skip-lint --copy-configs
+${ROOT}/bin/.cache/clj-kondo-${VERSION}/clj-kondo --lint "$(clojure -A:dev -Spath)" --dependencies --parallel
 exec "${ROOT}/bin/.cache/clj-kondo-${VERSION}/clj-kondo" "$@"

--- a/bin/lint
+++ b/bin/lint
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+./bin/clj-kondo --lint src:test

--- a/deps.edn
+++ b/deps.edn
@@ -43,6 +43,9 @@
   duct/hikaricp-component {:mvn/version "0.1.2"
                            :exclusions [org.slf4j/slf4j-nop]}
 
+  ;; manully imported clj-kondo configs from 2.x branch to .clj-kondo/imports/hiccup/hiccup
+  hiccup/hiccup {:mvn/version "1.0.5"}
+
   kirasystems/aging-session {:mvn/version "0.5.0"
                              :exclusions [org.clojure/clojurescript]}
 
@@ -114,6 +117,7 @@
 
                   eftest/eftest {:mvn/version "0.5.9"}
 
+                  ;; manually imported clj-kondo to .clj-kondo/imports/kerodon/kerodon
                   kerodon/kerodon {:mvn/version "0.9.1"}
 
                   net.polyc0l0r/bote {:mvn/version "0.1.0"}

--- a/src/clojars/tools/process_stats.clj
+++ b/src/clojars/tools/process_stats.clj
@@ -22,7 +22,8 @@
   (pattern [re] (.pattern re))
   (groupnames [_] [])
   re/RegexFragment
-  (static? [_ _] true))
+  (static? [_ _] true)
+  (recursimplify [_ _] (throw (ex-info "Not implemented" {}))))
 
 (def re-legacy-cdn
   "Log format used when we logged from fastly to rackspace cloudfiles"


### PR DESCRIPTION
As described in [the docs](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#importing), adding `--dependencies` will copy more accurate information to the clj-kondo cache.

This found a couple of minor issues like https://github.com/clojars/clojars-web/issues/904, but makes linting much more useful in the future.

You may need to manually clear `.clj-kondo/.cache` once.

I added an explicit dep on hiccup because we use it. Hiccup and kerodon need clj-kondo configs, which I temporarily added to `.clj-kondo/imports`. They will be overwritten if we bump these deps and they provide their own configs.

I didn't commit `.clj-kondo/imports` to keep the PR small, though it is recommended. In practice it won't make a difference, but add `!.clj-kondo/imports` to `.gitignore` to commit the imports.