### PR TITLE
Inline :defaults alias

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: check
 check:
-	clojure -M:defaults:check
+	clojure -M:check
 
 .PHONY: lint
 lint:
@@ -8,7 +8,7 @@ lint:
 
 .PHONY: migrate-db
 migrate-db:
-	clojure -M:defaults:migrate-db
+	clojure -M:migrate-db
 
 .PHONY: nvd-check
 nvd-check:
@@ -16,15 +16,15 @@ nvd-check:
 
 .PHONY: prep-deps
 prep-deps:
-	clojure -A:defaults -X:deps prep
+	clojure -X:deps prep
 
 .PHONY: repl
 repl:
-	clj -A:defaults:dev
+	clj -A:dev
 
 .PHONY: setup-dev-repo
 setup-dev-repo:
-	clojure -M:defaults:setup-dev-repo
+	clojure -M:setup-dev-repo
 
 .PHONY: tag-release
 tag-release:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Development
 
 ### Development system
 
-To begin developing, start with a REPL (Note: if you are instead starting a repl from your editor, you will need to include the `:default` and `:dev` aliases).
+To begin developing, start with a REPL (Note: if you are instead starting a repl from your editor, you will need to include the `:dev` alias).
 
 ```sh
 make repl

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-clojure -M:defaults:dev:test "$@"
+clojure -M:dev:test "$@"

--- a/bin/nvd-check
+++ b/bin/nvd-check
@@ -17,5 +17,5 @@ clojure -Ttools install nvd-clojure/nvd-clojure '{:mvn/version "5.0.0"}' :as nvd
 
 cd "$ROOT"
 clojure -J-Dclojure.main.report=stderr -Tnvd nvd.task/check \
-    :classpath '"'"$(clojure -Spath -A:defaults)"'"' \
+    :classpath '"'"$(clojure -Spath)"'"' \
     :config-filename '".nvd-clojure.edn"'

--- a/build.clj
+++ b/build.clj
@@ -6,7 +6,7 @@
     LocalDate)))
 
 (def class-dir "target/classes")
-(def basis (b/create-basis {:aliases [:defaults]}))
+(def basis (b/create-basis))
 (def uber-file "target/clojars-web-standalone.jar")
 
 (defn clean [_]

--- a/deps.edn
+++ b/deps.edn
@@ -85,24 +85,22 @@
   ring-jetty-component/ring-jetty-component {:mvn/version "0.3.1"}
   ring-middleware-format/ring-middleware-format {:mvn/version "0.7.5"}
 
-  valip/valip {:mvn/version "0.2.0"}}
+  valip/valip {:mvn/version "0.2.0"}
 
- :aliases {:defaults
-           ;; We use override-deps to address CVEs
-           {:override-deps
-            {;; Addresses CVE-2022-42004, CVE-2022-42003, CVE-2021-46877, CVE-2020-36518
-             com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.15.2"}
-             ;; Addresses CVE-2019-10086, CVE-2014-0114, CVE-2025-48734
-             commons-beanutils/commons-beanutils {:mvn/version "1.11.0"}
-             ;; Addresses CVE-2015-6420
-             commons-collections/commons-collections {:mvn/version "3.2.2"}
+  ;; # Address CVEs
+  ;; Addresses CVE-2022-42004, CVE-2022-42003, CVE-2021-46877, CVE-2020-36518
+  com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.15.2"}
+  ;; Addresses CVE-2019-10086, CVE-2014-0114, CVE-2025-48734
+  commons-beanutils/commons-beanutils {:mvn/version "1.11.0"}
+  ;; Addresses CVE-2015-6420
+  commons-collections/commons-collections {:mvn/version "3.2.2"}
 
-             ;; Addresses CVE-2015-0886
-             org.mindrot/jbcrypt {:mvn/version "0.4"}
-             ;; Addresses CVE-2022-25857, CVE-2022-38749, CVE-2022-41854, CVE-2022-38751, CVE-2022-38752, CVE-2022-38750
-             org.yaml/snakeyaml {:mvn/version "1.33"}}}
+  ;; Addresses CVE-2015-0886
+  org.mindrot/jbcrypt {:mvn/version "0.4"}
+  ;; Addresses CVE-2022-25857, CVE-2022-38749, CVE-2022-41854, CVE-2022-38751, CVE-2022-38752, CVE-2022-38750
+  org.yaml/snakeyaml {:mvn/version "1.33"}}
 
-           :build {:deps {io.github.clojure/tools.build {:mvn/version "0.9.5"}}
+ :aliases {:build {:deps {io.github.clojure/tools.build {:mvn/version "0.9.5"}}
                    :ns-default build}
 
            :check {:extra-deps {athos/clj-check {:git/url "https://github.com/athos/clj-check.git"


### PR DESCRIPTION
This should help avoid problems like https://github.com/clojars/clojars-web/commit/baade8967c7be8abd9a9b27499c511efd41f6164. Top-level deps always take precedence, so it's equivalent to just move the `:defaults :deps` to `:deps`.

Use `clojure -X:deps list` to audit the new dependency list, and compare it to `clojure -X:deps list :aliases '[:defaults]'` on main. They should be identical (tested on my machine).